### PR TITLE
Fix Script Warning, Provisional Point Cost

### DIFF
--- a/Starcore_Pointslist-Dev/Data/Scripts/Additions/PointAdditions.cs
+++ b/Starcore_Pointslist-Dev/Data/Scripts/Additions/PointAdditions.cs
@@ -17,6 +17,7 @@ namespace ShipPoints
                 LargeEnhancer@50;
                 LargeBlockSmallGenerator@17;
                 LargeBlockLargeGenerator@300;
+		LargeLargeBlockUpgrade@100
                 LargeWarhead@101;
                 LargeDecoy@4;
                 LargeStator@5;

--- a/UpgradableReactors/Data/Scripts/ReactorUpgrade/MyReactorUpgradeLogic.cs
+++ b/UpgradableReactors/Data/Scripts/ReactorUpgrade/MyReactorUpgradeLogic.cs
@@ -14,7 +14,7 @@ using VRage.Utils;
 
 namespace ReactorUpgrade
 {
-    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_Reactor))]
+    [MyEntityComponentDescriptor(typeof(MyObjectBuilder_Reactor),false)]
     public class MyReactorUpgradeLogic : MyGameLogicComponent
     {
         private IMyReactor m_reactor;


### PR DESCRIPTION
Fixed a Script Warning
Added a Provisional Point Cost for LargeLargeBlockUpgrade at 100 Points
