### PR TITLE
1 14 2024patch

### DIFF
--- a/Anomaly_Solaris_Hypernautics/Data/PM_LG_BLASTPLATE_BLASTPLATE.sbc
+++ b/Anomaly_Solaris_Hypernautics/Data/PM_LG_BLASTPLATE_BLASTPLATE.sbc
@@ -15,9 +15,9 @@
 			<ModelOffset x="0" y="0" z="0"/>
 			<Model>Models\Cubes\large\PM_LG_BLASTPLATE_BLASTPLATE.mwm</Model>
 			<Components>
-				<Component Subtype="SteelPlate" Count="750" />
-       		 	<Component Subtype="MetalGrid" Count="2500" />
-        		<Component Subtype="SteelPlate" Count="6750" />
+				<Component Subtype="SteelPlate" Count="1500" />
+       		 	<Component Subtype="MetalGrid" Count="5000" />
+        		<Component Subtype="SteelPlate" Count="13500" />
 			</Components>
 			<CriticalComponent Subtype="SteelPlate" Index="0"/>
 			<MountPoints>
@@ -33,7 +33,7 @@
       		<EdgeType>Heavy</EdgeType>
       		<BuildTimeSeconds>1800</BuildTimeSeconds>
       		<DisassembleRatio>0.5</DisassembleRatio>
-      		<GeneralDamageMultiplier>0.2</GeneralDamageMultiplier>
+      		<GeneralDamageMultiplier>0.4</GeneralDamageMultiplier>
       		<PCU>1</PCU>
       		<PCUConsole>2</PCUConsole>
       		<IsAirTight>true</IsAirTight>

--- a/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Crossfield Ammo.cs
+++ b/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Crossfield Ammo.cs
@@ -101,7 +101,7 @@ namespace Scripts
                 MaxIntegrity = 0f, // Blocks with integrity higher than this value will be immune to damage from this projectile; 0 = disabled.
                 DamageVoxels = false, // Whether to damage voxels.
                 SelfDamage = false, // Whether to damage the weapon's own grid.
-                HealthHitModifier = 1f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
+                HealthHitModifier = 2.5f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
                 VoxelHitModifier = 1, // Voxel damage multiplier; defaults to 1 if zero or less.
                 Characters = -1f, // Character damage multiplier; defaults to 1 if zero or less.
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.

--- a/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Esper_Ammo.cs
+++ b/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Esper_Ammo.cs
@@ -556,10 +556,10 @@ namespace Scripts
                 },
                 EndOfLife = new EndOfLifeDef
                 {
-                    Enable = false,
+                    Enable = true,
                     Radius = 3f, // Radius of AOE effect, in meters.
-                    Damage = 15000f,
-                    Depth = 3f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
+                    Damage = 5000f,
+                    Depth = 1f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
                     MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius

--- a/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Esper_Ammo.cs
+++ b/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Esper_Ammo.cs
@@ -556,9 +556,9 @@ namespace Scripts
                 },
                 EndOfLife = new EndOfLifeDef
                 {
-                    Enable = true,
+                    Enable = false,
                     Radius = 3f, // Radius of AOE effect, in meters.
-                    Damage = 5000f,
+                    Damage = 500f,
                     Depth = 1f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
                     MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius

--- a/Heavy-Assault-Systems/Data/Scripts/CoreParts/Crossfield Ammo.cs
+++ b/Heavy-Assault-Systems/Data/Scripts/CoreParts/Crossfield Ammo.cs
@@ -101,7 +101,7 @@ namespace Scripts
                 MaxIntegrity = 0f, // Blocks with integrity higher than this value will be immune to damage from this projectile; 0 = disabled.
                 DamageVoxels = false, // Whether to damage voxels.
                 SelfDamage = false, // Whether to damage the weapon's own grid.
-                HealthHitModifier = 1f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
+                HealthHitModifier = 2.5f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
                 VoxelHitModifier = 1, // Voxel damage multiplier; defaults to 1 if zero or less.
                 Characters = -1f, // Character damage multiplier; defaults to 1 if zero or less.
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.

--- a/Heavy-Assault-Systems/Data/Scripts/CoreParts/Esper_Ammo.cs
+++ b/Heavy-Assault-Systems/Data/Scripts/CoreParts/Esper_Ammo.cs
@@ -556,10 +556,10 @@ namespace Scripts
                 },
                 EndOfLife = new EndOfLifeDef
                 {
-                    Enable = false,
+                    Enable = true,
                     Radius = 3f, // Radius of AOE effect, in meters.
-                    Damage = 15000f,
-                    Depth = 3f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
+                    Damage = 5000f,
+                    Depth = 1f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
                     MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius

--- a/Heavy-Assault-Systems/Data/Scripts/CoreParts/Esper_Ammo.cs
+++ b/Heavy-Assault-Systems/Data/Scripts/CoreParts/Esper_Ammo.cs
@@ -556,9 +556,9 @@ namespace Scripts
                 },
                 EndOfLife = new EndOfLifeDef
                 {
-                    Enable = true,
+                    Enable = false,
                     Radius = 3f, // Radius of AOE effect, in meters.
-                    Damage = 5000f,
+                    Damage = 500f,
                     Depth = 1f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
                     MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius

--- a/NorseHeavyIndustries/Data/Scripts/Coreparts/NHI_Turreted/NHI_Gatling_Laser_Turret_Ammo.cs
+++ b/NorseHeavyIndustries/Data/Scripts/Coreparts/NHI_Turreted/NHI_Gatling_Laser_Turret_Ammo.cs
@@ -121,7 +121,7 @@ namespace Scripts
                     Armor = -1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = .75f, // Multiplier for damage against light armor.
                     Heavy = 2f, // Multiplier for damage against heavy armor.
-                    NonArmor = 1.5f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {

--- a/OnyxArmamentCo/Data/Scripts/CoreParts/PhaethonAmmo.cs
+++ b/OnyxArmamentCo/Data/Scripts/CoreParts/PhaethonAmmo.cs
@@ -136,7 +136,7 @@ namespace Scripts
                     Armor = 1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 1.7f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
@@ -1327,7 +1327,7 @@ namespace Scripts
                     Armor = -1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 2f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
@@ -1716,7 +1716,7 @@ namespace Scripts
                     Armor = 1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 3.3f, // Multiplier for damage against every else.
+                    NonArmor = -2f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {

--- a/REEECore-Dev/Data/Scripts/CoreParts/ERPPC_ammo.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/ERPPC_ammo.cs
@@ -172,7 +172,7 @@ namespace Scripts
                 {
                     Enable = true,
                     Radius = 5f, // Radius of AOE effect, in meters.
-                    Damage = 10000f,
+                    Damage = 50000f,
                     Depth = 2f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
                     MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
                     Falloff = Curve, //.NoFalloff applies the same damage to all blocks in radius

--- a/REEECore-Dev/Data/Scripts/CoreParts/New_Starcore_Ammo_PPC.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/New_Starcore_Ammo_PPC.cs
@@ -41,7 +41,7 @@ namespace Scripts
             AmmoRound = "PPC Main", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 38500f, // Direct damage; one steel plate is worth 100. 
+            BaseDamage = 1000f, // Direct damage; one steel plate is worth 100. 
             Mass = 5f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 9500f, // Recoil.
@@ -569,12 +569,12 @@ namespace Scripts
                 },
                 EndOfLife = new EndOfLifeDef
                 {
-                    Enable = false,
-                    Radius = 6f, // Meters
-                    Damage = 60000f,
-                    Depth = 4f,
-                    MaxAbsorb = 0f,
-                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    Enable = true,
+                    Radius = 5f, // Radius of AOE effect, in meters.
+                    Damage = 50000f,
+                    Depth = 2f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
+                    MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
+                    Falloff = Curve, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
                     //.Curve drops off damage sharply as it approaches the max radius
                     //.InvCurve drops off sharply from the middle and tapers to max radius

--- a/REEECore/Data/Scripts/CoreParts/ERPPC_ammo.cs
+++ b/REEECore/Data/Scripts/CoreParts/ERPPC_ammo.cs
@@ -172,7 +172,7 @@ namespace Scripts
                 {
                     Enable = true,
                     Radius = 5f, // Radius of AOE effect, in meters.
-                    Damage = 10000f,
+                    Damage = 50000f,
                     Depth = 2f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
                     MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
                     Falloff = Curve, //.NoFalloff applies the same damage to all blocks in radius

--- a/REEECore/Data/Scripts/CoreParts/New_Starcore_Ammo_PPC.cs
+++ b/REEECore/Data/Scripts/CoreParts/New_Starcore_Ammo_PPC.cs
@@ -41,7 +41,7 @@ namespace Scripts
             AmmoRound = "PPC Main", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 38500f, // Direct damage; one steel plate is worth 100. 
+            BaseDamage = 1000f, // Direct damage; one steel plate is worth 100. 
             Mass = 5f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 9500f, // Recoil.
@@ -569,12 +569,12 @@ namespace Scripts
                 },
                 EndOfLife = new EndOfLifeDef
                 {
-                    Enable = false,
-                    Radius = 6f, // Meters
-                    Damage = 60000f,
-                    Depth = 4f,
-                    MaxAbsorb = 0f,
-                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    Enable = true,
+                    Radius = 5f, // Radius of AOE effect, in meters.
+                    Damage = 50000f,
+                    Depth = 2f, // Max depth of AOE effect, in meters. 0=disabled, and AOE effect will reach to a depth of the radius value
+                    MaxAbsorb = 0f, // Soft cutoff for damage, except for pooled falloff.  If pooled falloff, limits max damage per block.
+                    Falloff = Curve, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
                     //.Curve drops off damage sharply as it approaches the max radius
                     //.InvCurve drops off sharply from the middle and tapers to max radius

--- a/REEECore/Data/Scripts/CoreParts/SC_Radome.cs
+++ b/REEECore/Data/Scripts/CoreParts/SC_Radome.cs
@@ -37,7 +37,7 @@ namespace Scripts
             Targeting = new TargetingDef  
             {
                 Threats = new[] {
-                    Grids, Projectiles,
+                    Grids, Projectiles
                 },
                 SubSystems = new[] {
                     Thrust, Utility, Offense, Power, Production, Any,
@@ -90,9 +90,9 @@ namespace Scripts
                 Ai = new AiDef
                 {
                     TrackTargets = true, // Whether this weapon tracks its own targets, or (for multiweapons) relies on the weapon with PrimaryTracking enabled for target designation. Turrets Need this set to True.
-                    TurretAttached = true, // Whether this weapon is a turret and should have the UI and API options for such. Turrets Need this set to True.
-                    TurretController = true, // Whether this weapon can physically control the turret's movement. Turrets Need this set to True.
-                    PrimaryTracking = true, // For multiweapons: whether this weapon should designate targets for other weapons on the platform without their own tracking.
+                    TurretAttached = false, // Whether this weapon is a turret and should have the UI and API options for such. Turrets Need this set to True.
+                    TurretController = false, // Whether this weapon can physically control the turret's movement. Turrets Need this set to True.
+                    PrimaryTracking = false, // For multiweapons: whether this weapon should designate targets for other weapons on the platform without their own tracking.
                     LockOnFocus = false, // If enabled, weapon will only fire at targets that have been HUD selected AND locked onto by pressing Numpad 0.
                     SuppressFire = false, // If enabled, weapon can only be fired manually.
                     OverrideLeads = false, // Disable target leading on fixed weapons, or allow it for turrets.

--- a/SCMobilityBlocks/Data/HugeHydro.sbc
+++ b/SCMobilityBlocks/Data/HugeHydro.sbc
@@ -33,6 +33,8 @@
                 <MountPoint Side="Bottom" StartX="0" StartY="0" EndX="5" EndY="5" />
                 <MountPoint Side="Left" StartX="0" StartY="0" EndX="5" EndY="5" />
                 <MountPoint Side="Top" StartX="0" StartY="0" EndX="5" EndY="5" />
+				<MountPoint Side="Front" StartX="0" StartY="0" EndX="5" EndY="5" />
+
             </MountPoints>
             <VoxelPlacement>
                 <!--Possible settings Both,InVoxel,OutsideVoxel,Volumetric. If volumetric set than MaxAllowed and MinAllowed will be used.-->

--- a/StarCoreCTF/Data/Scripts/CTF/CTF.cs
+++ b/StarCoreCTF/Data/Scripts/CTF/CTF.cs
@@ -26,6 +26,8 @@ namespace Klime.CTF
     public class CTF : MySessionComponentBase
     {
         private static readonly StringBuilder GripBracketConst = new StringBuilder("[       ]");
+        private static readonly StringBuilder DMGResistConst = new StringBuilder("DMG Resist!");
+
 
         List<Flag> allflags = new List<Flag>();
         GameState gamestate;
@@ -917,22 +919,31 @@ namespace Klime.CTF
                                         {
                                             if (faction_tag != "")
                                             {
+                                                IMyCockpit cockpit = (IMyCockpit)controlledEntity;
+                                                long gridEntityId = cockpit.CubeGrid.EntityId;
                                                 subflag.state = FlagState.Active;
                                                 ShowANotificationPlease("flag set to active 1");
                                                 subflag.carrying_player_id = player.IdentityId;
                                                 subflag.carrying_player = player;
                                                 SendEvent(player.DisplayName + " grabbed the flag!", InfoType.FlagTaken);
+                                                MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 0.5f);
+
                                             }
                                         }
                                         else
                                         {
                                             if (faction_tag != "" && faction_tag != subflag.owning_faction.Tag)
                                             {
+
+                                                IMyCockpit cockpit = (IMyCockpit)controlledEntity;
+                                                long gridEntityId = cockpit.CubeGrid.EntityId;
                                                 subflag.state = FlagState.Active;
                                                 ShowANotificationPlease("flag set to active 2");
                                                 subflag.carrying_player_id = player.IdentityId;
                                                 subflag.carrying_player = player;
                                                 SendEvent(player.DisplayName + " stole " + subflag.owning_faction.Tag + " flag!", InfoType.FlagTaken);
+                                                MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 0.5f);
+
                                             }
                                         }
                                     }
@@ -1031,7 +1042,12 @@ namespace Klime.CTF
                                         }
 
 
-
+                                        //give the flagbearer damage resistance to their grid!
+                                        if (controlledEntity is IMyCockpit)
+                                        {
+                                            
+                                            MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 0.5f); // Applying 0.5x damage modifier
+                                        }
 
 
                                         //    MathHelper.Smooth(regen_temp, subflag.grip_strength);
@@ -1044,6 +1060,7 @@ namespace Klime.CTF
                                             subflag.state = FlagState.Dropped;
                                             ShowANotificationPlease("flag dropped 2");
                                             SendEvent(subflag.carrying_player.DisplayName + " dropped " + subflag.owning_faction.Tag + " the flag!", InfoType.FlagDropped);
+                                            MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 1.0f); // Applying 0.5x damage modifier
 
                                             playerDropTimes[subflag.carrying_player.IdentityId] = timer;
                                         }
@@ -1055,6 +1072,9 @@ namespace Klime.CTF
                                         reuse_matrix.Translation += reuse_matrix.Backward * 0.4f + reuse_matrix.Up * 1.5f + reuse_matrix.Left * 0.25f;
                                         subflag.flag_entity.WorldMatrix = reuse_matrix;
 
+                                        IMyCockpit cockpit = (IMyCockpit)controlledEntity;
+                                        long gridEntityId = cockpit.CubeGrid.EntityId;
+
                                         // Check for cockpit and drop flag if conditions are met
                                         if (drop_in_cockpit && !pickup_in_cockpit)
                                         {
@@ -1063,6 +1083,8 @@ namespace Klime.CTF
                                                 subflag.state = FlagState.Dropped;
                                                 ShowANotificationPlease("flag dropped 3");
                                                 SendEvent(subflag.carrying_player.DisplayName + " dropped " + subflag.owning_faction.Tag + " flag!", InfoType.FlagDropped);
+                                                MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 1.0f); 
+
                                             }
                                         }
 
@@ -1075,6 +1097,8 @@ namespace Klime.CTF
                                                 subflag.state = FlagState.Dropped;
                                                 ShowANotificationPlease("flag dropped 4");
                                                 SendEvent(subflag.carrying_player.DisplayName + " dropped " + subflag.owning_faction.Tag + " flag!", InfoType.FlagDropped);
+                                                MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 1.0f);
+
                                             }
                                         }
 
@@ -1158,15 +1182,22 @@ namespace Klime.CTF
                                     }
                                     else
                                     {
+                                        IMyCockpit cockpit = (IMyCockpit)controlledEntity;
+                                        long gridEntityId = cockpit.CubeGrid.EntityId;
+
                                         subflag.state = FlagState.Dropped;
                                         ShowANotificationPlease("flag dropped 4");
                                         if (subflag.flag_type == FlagType.Single)
                                         {
                                             SendEvent(subflag.carrying_player.DisplayName + " dropped the flag!", InfoType.FlagDropped);
+                                            MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 1.0f);
+
                                         }
                                         else
                                         {
                                             SendEvent(subflag.carrying_player.DisplayName + " dropped " + subflag.owning_faction.Tag + " flag!", InfoType.FlagDropped);
+                                            MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 1.0f);
+
                                         }
                                     }
 
@@ -1305,6 +1336,7 @@ namespace Klime.CTF
                                                 subflag.carrying_player = player;
                                                 subflag.current_drop_life = 0;
                                                 SendEvent(player.DisplayName + " grabbed the flag!", InfoType.FlagTaken);
+                                               // MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 0.5f);
                                             }
                                         }
                                         else
@@ -1317,6 +1349,8 @@ namespace Klime.CTF
                                                 subflag.carrying_player = player;
                                                 subflag.current_drop_life = 0;
                                                 SendEvent(player.DisplayName + " stole " + subflag.owning_faction.Tag + " flag!", InfoType.FlagTaken);
+                                                //MyVisualScriptLogicProvider.SetGridGeneralDamageModifier(cockpit.CubeGrid.Name, 0.5f);
+
                                             }
                                         }
                                     }
@@ -1492,8 +1526,8 @@ namespace Klime.CTF
 
                         // You will need to adjust these coordinates based on where the "RED" and "BLU" text are.
                         // For example, if "RED" is centered at X = 0.30, you might use X = 0.28 for the grip bar.
-                        Vector2D redPosition = new Vector2D(-0.33, 0.85); // Position directly below the "RED" text
-                        Vector2D bluePosition = new Vector2D(-0.43, 0.85); // Position directly below the "BLU" text
+                        Vector2D bluePosition = new Vector2D(-0.33, 0.85); // Position directly below the "RED" text
+                        Vector2D redPosition = new Vector2D(-0.43, 0.85); // Position directly below the "BLU" text
 
                         StringBuilder redGripSb = new StringBuilder();
                         redGripSb.Append(redGripBar);
@@ -1510,6 +1544,11 @@ namespace Klime.CTF
                             var redGripBracket = new HudAPIv2.HUDMessage(GripBracketConst, redPosition, TimeToLive: 2, Scale: 2f, Blend: BlendTypeEnum.PostPP);
                             redGripBracket.Origin -= redGripBracket.GetTextLength() * Vector2D.UnitX / 10;
                             redGripBracket.InitialColor = Color.Red;
+
+                            var redGripDmgResistWarning = new HudAPIv2.HUDMessage(DMGResistConst, redPosition, TimeToLive: 2, Scale: 1f, Blend: BlendTypeEnum.PostPP);
+                            redGripDmgResistWarning.InitialColor = Color.Red;
+                            redGripDmgResistWarning.Origin -= redGripBracket.GetTextLength() * (Vector2D.UnitX / 10);
+
                         }
 
                         if (blueFlag.state == FlagState.Active)
@@ -1517,6 +1556,11 @@ namespace Klime.CTF
                             var blueGripBracket = new HudAPIv2.HUDMessage(GripBracketConst, bluePosition, TimeToLive: 2, Scale: 2f, Blend: BlendTypeEnum.PostPP);
                             blueGripBracket.Origin -= blueGripBracket.GetTextLength() * Vector2D.UnitX / 10;
                             blueGripBracket.InitialColor = Color.Blue;
+
+                            var bluGripDmgResistWarning = new HudAPIv2.HUDMessage(DMGResistConst, bluePosition, TimeToLive: 2, Scale: 1f, Blend: BlendTypeEnum.PostPP);
+                            bluGripDmgResistWarning.Origin -= bluGripDmgResistWarning.GetTextLength() * (Vector2D.UnitX / 10);
+                            bluGripDmgResistWarning.InitialColor = Color.Blue;
+
                         }
                     }
 

--- a/StarCoreCTF/Data/Scripts/CTF/CTF.cs
+++ b/StarCoreCTF/Data/Scripts/CTF/CTF.cs
@@ -26,7 +26,7 @@ namespace Klime.CTF
     public class CTF : MySessionComponentBase
     {
         private static readonly StringBuilder GripBracketConst = new StringBuilder("[       ]");
-        private static readonly StringBuilder DMGResistConst = new StringBuilder("DMG Resist!");
+        private static readonly StringBuilder DMGResistConst = new StringBuilder("RESIST+");
 
 
         List<Flag> allflags = new List<Flag>();
@@ -1539,15 +1539,17 @@ namespace Klime.CTF
                         var blueGripMessage = new HudAPIv2.HUDMessage(blueGripSb, bluePosition, TimeToLive: 2, Scale: 2f, Blend: BlendTypeEnum.PostPP);
                         blueGripMessage.InitialColor = Color.Blue;
 
+                        const double VerticalOffsetForDamageResistText = +0.03; // Adjust this value as needed
+
                         if (redFlag.state == FlagState.Active)
                         {
                             var redGripBracket = new HudAPIv2.HUDMessage(GripBracketConst, redPosition, TimeToLive: 2, Scale: 2f, Blend: BlendTypeEnum.PostPP);
                             redGripBracket.Origin -= redGripBracket.GetTextLength() * Vector2D.UnitX / 10;
                             redGripBracket.InitialColor = Color.Red;
 
-                            var redGripDmgResistWarning = new HudAPIv2.HUDMessage(DMGResistConst, redPosition, TimeToLive: 2, Scale: 1f, Blend: BlendTypeEnum.PostPP);
+                            Vector2D redDmgResistPosition = new Vector2D(redPosition.X, redPosition.Y + VerticalOffsetForDamageResistText);
+                            var redGripDmgResistWarning = new HudAPIv2.HUDMessage(DMGResistConst, redDmgResistPosition, TimeToLive: 2, Scale: 1f, Blend: BlendTypeEnum.PostPP);
                             redGripDmgResistWarning.InitialColor = Color.Red;
-                            redGripDmgResistWarning.Origin -= redGripBracket.GetTextLength() * (Vector2D.UnitX / 10);
 
                         }
 
@@ -1557,8 +1559,8 @@ namespace Klime.CTF
                             blueGripBracket.Origin -= blueGripBracket.GetTextLength() * Vector2D.UnitX / 10;
                             blueGripBracket.InitialColor = Color.Blue;
 
-                            var bluGripDmgResistWarning = new HudAPIv2.HUDMessage(DMGResistConst, bluePosition, TimeToLive: 2, Scale: 1f, Blend: BlendTypeEnum.PostPP);
-                            bluGripDmgResistWarning.Origin -= bluGripDmgResistWarning.GetTextLength() * (Vector2D.UnitX / 10);
+                            Vector2D blueDmgResistPosition = new Vector2D(bluePosition.X, bluePosition.Y + VerticalOffsetForDamageResistText);
+                            var bluGripDmgResistWarning = new HudAPIv2.HUDMessage(DMGResistConst, blueDmgResistPosition, TimeToLive: 2, Scale: 1f, Blend: BlendTypeEnum.PostPP);
                             bluGripDmgResistWarning.InitialColor = Color.Blue;
 
                         }

--- a/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T2_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T2_Ammo.cs
@@ -39,7 +39,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T2_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 2f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 125f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
@@ -108,7 +108,7 @@ namespace Scripts
                 MaxIntegrity = 0f, // Blocks with integrity higher than this value will be immune to damage from this projectile; 0 = disabled.
                 DamageVoxels = false, // Whether to damage voxels.
                 SelfDamage = false, // Whether to damage the weapon's own grid.
-                HealthHitModifier = 1.25f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
+                HealthHitModifier = 2f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
                 VoxelHitModifier = 1, // Voxel damage multiplier; defaults to 1 if zero or less.
                 Characters = 1f, // Character damage multiplier; defaults to 1 if zero or less.
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.

--- a/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
@@ -437,7 +437,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_Gladius_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 2f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 275f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
@@ -38,7 +38,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T3_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 2f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 275f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T4_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod-Dev/Data/Scripts/CoreParts/MA_Laser_T4_Ammo.cs
@@ -38,7 +38,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T4_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 2.5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 110f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T2_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T2_Ammo.cs
@@ -39,7 +39,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T2_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 2f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 125f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
@@ -108,7 +108,7 @@ namespace Scripts
                 MaxIntegrity = 0f, // Blocks with integrity higher than this value will be immune to damage from this projectile; 0 = disabled.
                 DamageVoxels = false, // Whether to damage voxels.
                 SelfDamage = false, // Whether to damage the weapon's own grid.
-                HealthHitModifier = 1.25f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
+                HealthHitModifier = 2f, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
                 VoxelHitModifier = 1, // Voxel damage multiplier; defaults to 1 if zero or less.
                 Characters = 1f, // Character damage multiplier; defaults to 1 if zero or less.
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.

--- a/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
@@ -38,7 +38,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T3_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 2f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 275f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T4_Ammo.cs
+++ b/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T4_Ammo.cs
@@ -38,7 +38,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T4_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 2.5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 110f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Starcore_Serpent_Arms_Heavy_Metal/Data/Scripts/CoreParts/Hellfire_Laser_Ammo.cs
+++ b/Starcore_Serpent_Arms_Heavy_Metal/Data/Scripts/CoreParts/Hellfire_Laser_Ammo.cs
@@ -120,11 +120,11 @@ namespace Scripts
                     Armor = -1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = 0.4f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 1.5f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 8f, // Multiplier for damage against shields.
+                    Modifier = 6f, // Multiplier for damage against shields.
                     Type = Default, // Damage vs healing against shields; Default, Heal
                     BypassModifier = -1f, // If greater than zero, the percentage of damage that will penetrate the shield.
                 },
@@ -268,7 +268,7 @@ namespace Scripts
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed. Be warned, you can make your projectile go backwards.
                 RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
-                MaxTrajectoryTime = 120, // How long the weapon must fire before it reaches MaxTrajectory.
+                MaxTrajectoryTime = 300, // How long the weapon must fire before it reaches MaxTrajectory.
                 Smarts = new SmartsDef
                 {
                     Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.

--- a/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracker.cs
+++ b/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracker.cs
@@ -601,10 +601,6 @@ namespace klime.PointCheck
                     t_N = "Large Laser";
                     mCs = 0.15f;
                     break;
-                case "Reinforced Blastplate":
-                    t_N = "Reinforced Blastplate";
-                    mCs = 0.25f;
-                    break;
             }
         }
 

--- a/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracker.cs
+++ b/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracker.cs
@@ -601,6 +601,10 @@ namespace klime.PointCheck
                     t_N = "Large Laser";
                     mCs = 0.15f;
                     break;
+                case "Reinforced Blastplate":
+                    t_N = "Reinforced Blastplate";
+                    mCs = 0.25f;
+                    break;
             }
         }
 

--- a/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracker.cs
+++ b/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracker.cs
@@ -565,20 +565,20 @@ namespace klime.PointCheck
                     t_N = "UNN Heavy Torpedo Launcher";
                     mCs = 0.15f;
                     break;
-                 case "Short Range Missile 8":
-                    t_N = "Short Range Missile 8";
+                 case "SRM-8":
+                    t_N = "SRM-8";
                     mCs = 0.15f;
                     break;
-                 case "Arrow IV":
-                    t_N = "Arrow IV";
+                 case "Starcore Arrow-IV Launcher":
+                    t_N = "Starcore Arrow-IV Launcher";
                     mCs = 0.15f;
                     break;
-                case "Tartarus":
-                    t_N = "Tartarus";
+                case "Tartarus VIII":
+                    t_N = "Tartarus VIII";
                     mCs = 0.15f;
                     break;
-                case "Cocytis":
-                    t_N = "Cocytis";
+                case "Cocytus IX":
+                    t_N = "Cocytus IX";
                     mCs = 0.15f;
                     break;
                 case "MCRN Torpedo Launcher":
@@ -589,8 +589,16 @@ namespace klime.PointCheck
                     t_N = "Flares";
                     mCs = 0.25f;
                     break;
-                case "Chiasim Arc Emitter":
-                    t_N = "Chiasim Arc Emitter";
+                case "Chiasim [Arc Emitter]":
+                    t_N = "Chiasim [Arc Emitter]";
+                    mCs = 0.15f;
+                    break;
+                case "Medium Laser":
+                    t_N = "Medium Laser";
+                    mCs = 0.15f;
+                    break;
+                case "Large Laser":
+                    t_N = "Large Laser";
                     mCs = 0.15f;
                     break;
             }


### PR DESCRIPTION
TL;DR fix climbing costs on weapons not showing up; reduce component killing abilities of egregious hitscan stuff; blastplate is heavier; holding the flag gives 50% damage resist

![image](https://github.com/StarCoreSE/SCModRepository/assets/51190031/315e881a-cdc2-4592-adae-73829024ff00)


- pickme should spawn teams at actual spawn positions now (the coordinates were in the global game storage not the world one haha)
- ERPPC does this per volley instead of literally one block (ppc fires one shot but has a smaller profile)
![image](https://github.com/StarCoreSE/SCModRepository/assets/51190031/54486ddf-98d7-4378-965d-6411caa728c7)

- fixed climbing costs not showing up on many smart weapons
- medium and large laser 15% climbing cost like the good old days
- 5x5 hydro has a mount point on the face so afterburners can be placeed on it
- Hellfire laser component damage 1.5 -> 1, MaxTrajectoryTime 120 > 300
- MA laser T2, T3, T4 energy cost reduced by half 1 (T2 125mw, T3 225MW, Gladius 550MW, T4 1375MW)
- Reinforced Blastplate resistance 0.2x -> 0.4x, #of components doubled (increases mass from ~120t to 330t) (has the same hp)
- Surtur nonarmor 1.5f -> 1f
- phaethon zap beam ammo nonarmor 3.3 -> 2.0