### PR TITLE
missiles slooowwwweeerrrr + some other fixes

### DIFF
--- a/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Mammon_Ammo.cs
+++ b/Heavy-Assault-Systems-Dev/Data/Scripts/CoreParts/Mammon_Ammo.cs
@@ -34,7 +34,7 @@ namespace Scripts
         {
             AmmoMagazine = "MammonAmmoMag", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "Mammon Beam", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
-            HybridRound = false, // Use both a physical ammo magazine and energy per shot.
+            HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.175f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 1600f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.

--- a/Heavy-Assault-Systems/Data/Scripts/CoreParts/Mammon_Ammo.cs
+++ b/Heavy-Assault-Systems/Data/Scripts/CoreParts/Mammon_Ammo.cs
@@ -34,7 +34,7 @@ namespace Scripts
         {
             AmmoMagazine = "MammonAmmoMag", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "Mammon Beam", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
-            HybridRound = false, // Use both a physical ammo magazine and energy per shot.
+            HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.175f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 1600f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.

--- a/Invalids Vanilla Lobotomizer/Data/Scripts/CoreParts/AmmoTypes.cs
+++ b/Invalids Vanilla Lobotomizer/Data/Scripts/CoreParts/AmmoTypes.cs
@@ -2383,11 +2383,11 @@ namespace Scripts
                     Armor = 1.85f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 2f, // Multiplier for damage against every else.
+                    NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 8f, // Multiplier for damage against shields.
+                    Modifier = 5f, // Multiplier for damage against shields.
                     Type = Default, // Damage vs healing against shields; Default, Heal
                     BypassModifier = -1f, // If greater than zero, the percentage of damage that will penetrate the shield.
                 },

--- a/Military Industrial Complex/Data/Scripts/CoreParts/SLAMMO.cs
+++ b/Military Industrial Complex/Data/Scripts/CoreParts/SLAMMO.cs
@@ -901,7 +901,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 8000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 110f,
-                DesiredSpeed = 3700, // voxel phasing if you go above 5100
+                DesiredSpeed = 2220, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1298,7 +1298,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 500, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 110f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 3700, // voxel phasing if you go above 5100
+                DesiredSpeed = 2220, // voxel phasing if you go above 5100
                 MaxTrajectory = 4000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1682,7 +1682,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 1, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 16,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Afflictor.sbc
+++ b/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Afflictor.sbc
@@ -42,6 +42,8 @@
 			<BuildProgressModels>
 			</BuildProgressModels>
 			<BlockPairName>SC_AR_Afflictor</BlockPairName>
+      <MirroringY>Z</MirroringY>
+      <MirroringZ>Y</MirroringZ>
 			<BuildTimeSeconds>60</BuildTimeSeconds>
 			<EdgeType>Light</EdgeType>
 			<WeaponDefinitionId Subtype="SCGenericWepDef" />

--- a/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Afflictor_Slanted.sbc
+++ b/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Afflictor_Slanted.sbc
@@ -43,6 +43,8 @@
 			</BuildProgressModels>
 			<BlockPairName>SC_AR_Afflictor_Slanted</BlockPairName>
 			<BuildTimeSeconds>60</BuildTimeSeconds>
+      <MirroringY>Z</MirroringY>
+      <MirroringZ>Y</MirroringZ>
 			<EdgeType>Light</EdgeType>
 			<WeaponDefinitionId Subtype="SCGenericWepDef" />
 			<OverlayTexture>Textures\GUI\Screens\turret_overlay.dds</OverlayTexture>

--- a/OnyxArmamentCo/Data/CubeBlocks/SC_AR_CataclysmicVariable.sbc
+++ b/OnyxArmamentCo/Data/CubeBlocks/SC_AR_CataclysmicVariable.sbc
@@ -48,6 +48,8 @@
 			</BuildProgressModels>	-->
 			<BlockPairName>SC_AR_CataclysmicVariable</BlockPairName>
 			<BuildTimeSeconds>150</BuildTimeSeconds>
+      <MirroringY>Z</MirroringY>
+      <MirroringZ>Y</MirroringZ>
 			<EdgeType>Light</EdgeType>
 			<WeaponDefinitionId Subtype="SCGenericWepDef" />
 			<OverlayTexture>Textures\GUI\Screens\turret_overlay.dds</OverlayTexture>

--- a/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Phaethon.sbc
+++ b/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Phaethon.sbc
@@ -14,7 +14,7 @@
         Magazine Capacity: [4]
         Rate of Fire: [260]
         Reload Speed: [6 seconds]
-        Ammunition: [600m/s,] [Energy]
+        Ammunition: [270/s,] [Energy]
         ZAP:
         [Repeatedly zaps target]
         BAP:

--- a/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Resheph.sbc
+++ b/OnyxArmamentCo/Data/CubeBlocks/SC_AR_Resheph.sbc
@@ -37,6 +37,8 @@
 			<OverlayTexture>Textures\GUI\Screens\turret_overlay.dds</OverlayTexture>
 			<BlockPairName>SC_AR_Resheph</BlockPairName>
 			<BuildTimeSeconds>120</BuildTimeSeconds>
+      <MirroringY>Z</MirroringY>
+      <MirroringZ>Y</MirroringZ>
 			<EdgeType>Light</EdgeType>
 			<WeaponDefinitionId Subtype="SCGenericWepDef" />
 			<ResourceSinkGroup>Defense</ResourceSinkGroup>

--- a/OnyxArmamentCo/Data/Scripts/CoreParts/CataclysmicVariable_Ammo.cs
+++ b/OnyxArmamentCo/Data/Scripts/CoreParts/CataclysmicVariable_Ammo.cs
@@ -440,7 +440,7 @@ namespace Scripts
                                //float.MaxValue will drop the weapon to the first build state and destroy all components used for construction
                                //If greater than cube integrity it will remove the cube upon firing, without causing deformation (makes it look like the whole "block" flew away)
             HardPointUsable = true, // Whether this is a primary ammo type fired directly by the turret. Set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
-            EnergyMagazineSize = 999, // For energy weapons, how many shots to fire before reloading.
+            EnergyMagazineSize = 12, // For energy weapons, how many shots to fire before reloading.
             IgnoreWater = false, // Whether the projectile should be able to penetrate water when using WaterMod.
             IgnoreVoxels = false, // Whether the projectile should be able to penetrate voxels.
             Synchronize = false, // For future use

--- a/OnyxArmamentCo/Data/Scripts/CoreParts/PhaethonAmmo.cs
+++ b/OnyxArmamentCo/Data/Scripts/CoreParts/PhaethonAmmo.cs
@@ -1074,7 +1074,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 1900, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 1600, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 450, // voxel phasing if you go above 5100
+                DesiredSpeed = 270, // voxel phasing if you go above 5100
                 MaxTrajectory = 6000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/REEECore-Dev/Data/CubeBlocks_SC.sbc
+++ b/REEECore-Dev/Data/CubeBlocks_SC.sbc
@@ -364,16 +364,11 @@
      </Id>
      <DisplayName>PPC - Particle Projector Cannon</DisplayName>
      <Description>
-       Long Ranged Fixed: [15km]
-       Magazine Capacity: [1]
-       Rate of Fire: [120]
-       Reload Speed: [15 seconds]
-       Ammunition: [1100m/s,] [Kinetic]
-       APHE 600mm:
-       [Penetration fuse]
-       HE 600mm:
-       [Contact fuse, more damage]
-       [75mw passive draw]
+       [5km Range]
+       [2400 m/s]
+       [Magazine of 1]
+       [Energy Damage]
+       [Draws ~80mw]
      </Description>
      <Icon>Textures\Icons\ppc.dds</Icon>
      <CubeSize>Large</CubeSize>

--- a/REEECore-Dev/Data/CubeBlocks_SC_Arrow.sbc
+++ b/REEECore-Dev/Data/CubeBlocks_SC_Arrow.sbc
@@ -14,7 +14,7 @@
       [12km Targeting Range]
       [500m minimum range]
       [Energy damage]
-      [370~ m/s] 
+      [400~ m/s] 
       [Does not reload]
       Fires decoys when near the target to confuse point defense.
 	 </Description>

--- a/REEECore-Dev/Data/CubeBlocks_SC_Modular.sbc
+++ b/REEECore-Dev/Data/CubeBlocks_SC_Modular.sbc
@@ -11,7 +11,7 @@
      <DisplayName>LRM-5 Modular Launcher</DisplayName>
 	  <Description>
       [10km Targeting Range]
-      [850 m/s]
+      [510 m/s]
       [Energy Damage]
       [Does not reload]
       [5 Missiles]
@@ -65,7 +65,7 @@
      </Id>
      <DisplayName>LRM-5 Modular Launcher Middle</DisplayName>
 	  <Description>[10km Targeting Range]
-    [650 m/s]
+    [390 m/s]
     [Energy Damage]
     [Does not reload]
     [5 Missiles]
@@ -109,7 +109,7 @@
      </Id>
      <DisplayName>LRM-5 Modular Launcher 45</DisplayName>
 	  <Description>[10km Targeting Range]
-    [650 m/s]
+    [390 m/s]
     [Energy Damage]
     [Does not reload]
     [5 Missiles]
@@ -154,7 +154,7 @@
      </Id>
      <DisplayName>LRM-5 Modular Launcher 45 Reversed</DisplayName>
       <Description>[10km Targeting Range]
-    [650 m/s]
+    [390 m/s]
     [Energy Damage]
     [Does not reload]
     [5 Missiles]
@@ -200,7 +200,7 @@
      <DisplayName>MRM-10 Modular Launcher</DisplayName>
 	  <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -257,7 +257,7 @@
      <DisplayName>MRM-10 Modular Launcher Middle</DisplayName>
 	  <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -314,7 +314,7 @@
      <DisplayName>MRM-10 Modular Launcher 45</DisplayName>
       <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -360,7 +360,7 @@
      <DisplayName>MRM-10 Modular Launcher 45 Reversed</DisplayName>
       <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -404,7 +404,7 @@
      </Id>
      <DisplayName>SRM-8</DisplayName>
 	  <Description>[3.5km Range]
-    [700~ m/s]
+    [420~ m/s]
     [Energy Damage]
     [Does not reload]
     Effective against armor, shields and modules.

--- a/REEECore-Dev/Data/Cubeblocks_ERPPC.sbc
+++ b/REEECore-Dev/Data/Cubeblocks_ERPPC.sbc
@@ -13,6 +13,7 @@
       <Description>
         [5km Range]
         [2400 m/s]
+        [Magazine of 2]
         [Energy Damage]
         [Draws ~250mw]
 

--- a/REEECore-Dev/Data/Cubeblocks_SC_E.sbc
+++ b/REEECore-Dev/Data/Cubeblocks_SC_E.sbc
@@ -14,7 +14,7 @@
       <Description>
         [20km max range]
         [Energy damage]
-        [800~ m/s]
+        [480~ m/s]
         [Reloads 6 times]
       </Description>
       <Icon>Textures\Icons\MCRNHeavy.png</Icon>
@@ -70,7 +70,7 @@
       <Description>
         [12km max range]
         [Energy damage]
-        [800~ m/s]
+        [480~ m/s]
         [Reloads 4 times]
         Effective against most targets, more vulnerable to point defense than other launchers.
       </Description>

--- a/REEECore-Dev/Data/Scripts/CoreParts/E_Starcore_MCRN_Heavy_Ammo.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/E_Starcore_MCRN_Heavy_Ammo.cs
@@ -645,7 +645,7 @@ namespace Scripts
                 TargetLossTime = 0 , // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400 , // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 300f ,
-                DesiredSpeed = 800 , // voxel phasing if you go above 5100
+                DesiredSpeed = 480 , // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f ,
                 DeaccelTime = 0 , // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f , // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1034,7 +1034,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 800f,
-                DesiredSpeed = 600, // voxel phasing if you go above 5100
+                DesiredSpeed = 360, // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1403,7 +1403,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 100,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/REEECore-Dev/Data/Scripts/CoreParts/E_Starcore_UNN_Heavy_Ammo.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/E_Starcore_UNN_Heavy_Ammo.cs
@@ -644,7 +644,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 300f,
-                DesiredSpeed = 800, // voxel phasing if you go above 5100
+                DesiredSpeed = 480, // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1033,7 +1033,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 800f,
-                DesiredSpeed = 600, // voxel phasing if you go above 5100
+                DesiredSpeed = 360, // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1402,7 +1402,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 100,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/REEECore-Dev/Data/Scripts/CoreParts/STARCORE_Modular_LRM_Ammo.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/STARCORE_Modular_LRM_Ammo.cs
@@ -678,7 +678,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 3400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 245, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 850, // voxel phasing if you go above 5100
+                DesiredSpeed = 510, // voxel phasing if you go above 5100
                 MaxTrajectory = 15000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/REEECore-Dev/Data/Scripts/CoreParts/STARCORE_Modular_MRM_Ammo.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/STARCORE_Modular_MRM_Ammo.cs
@@ -290,7 +290,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 120, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 2670, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 900, // voxel phasing if you go above 5100
+                DesiredSpeed = 540, // voxel phasing if you go above 5100
                 MaxTrajectory = 7000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -715,7 +715,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 900, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 900, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 1000, // voxel phasing if you go above 5100
+                DesiredSpeed = 600, // voxel phasing if you go above 5100
                 MaxTrajectory = 7000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1129,7 +1129,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 3300, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 450f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 850, // voxel phasing if you go above 5100
+                DesiredSpeed = 510, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1518,7 +1518,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 0, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 1800, // voxel phasing if you go above 5100
+                DesiredSpeed = 1080, // voxel phasing if you go above 5100
                 MaxTrajectory = 1000, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1899,7 +1899,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 0, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 3800, // voxel phasing if you go above 5100
+                DesiredSpeed = 2280, // voxel phasing if you go above 5100
                 MaxTrajectory = 100, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/REEECore-Dev/Data/Scripts/CoreParts/Starcore_Ammo_Arrow.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/Starcore_Ammo_Arrow.cs
@@ -673,7 +673,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 8000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 110f,
-                DesiredSpeed = 670, // voxel phasing if you go above 5100
+                DesiredSpeed = 400, // voxel phasing if you go above 5100
                 MaxTrajectory = 45000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1071,7 +1071,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 8000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 420f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 670, // voxel phasing if you go above 5100
+                DesiredSpeed = 400, // voxel phasing if you go above 5100
                 MaxTrajectory = 45000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1398,7 +1398,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 1, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 16,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1789,7 +1789,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 560, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 475f,
-                DesiredSpeed = 675, // voxel phasing if you go above 5100
+                DesiredSpeed = 400, // voxel phasing if you go above 5100
                 MaxTrajectory = 3500,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0.75f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/REEECore-Dev/Data/Scripts/CoreParts/Starcore_SRM_Ammo.cs
+++ b/REEECore-Dev/Data/Scripts/CoreParts/Starcore_SRM_Ammo.cs
@@ -285,7 +285,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 30, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 1800, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 245, // voxel phasing if you go above 5100
+                DesiredSpeed = 147, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -700,7 +700,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 1900, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 550f, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 650, // voxel phasing if you go above 5100
+                DesiredSpeed = 390, // voxel phasing if you go above 5100
                 MaxTrajectory = 7000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1092,7 +1092,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 0f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 9000, // voxel phasing if you go above 5100
+                DesiredSpeed = 5400, // voxel phasing if you go above 5100
                 MaxTrajectory = 15, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/REEECore/Data/CubeBlocks_SC.sbc
+++ b/REEECore/Data/CubeBlocks_SC.sbc
@@ -364,16 +364,11 @@
      </Id>
      <DisplayName>PPC - Particle Projector Cannon</DisplayName>
      <Description>
-       Long Ranged Fixed: [15km]
-       Magazine Capacity: [1]
-       Rate of Fire: [120]
-       Reload Speed: [15 seconds]
-       Ammunition: [1100m/s,] [Kinetic]
-       APHE 600mm:
-       [Penetration fuse]
-       HE 600mm:
-       [Contact fuse, more damage]
-       [75mw passive draw]
+       [5km Range]
+       [2400 m/s]
+       [Magazine of 1]
+       [Energy Damage]
+       [Draws ~80mw]
      </Description>
      <Icon>Textures\Icons\ppc.dds</Icon>
      <CubeSize>Large</CubeSize>

--- a/REEECore/Data/CubeBlocks_SC_Arrow.sbc
+++ b/REEECore/Data/CubeBlocks_SC_Arrow.sbc
@@ -14,7 +14,7 @@
       [12km Targeting Range]
       [500m minimum range]
       [Energy damage]
-      [370~ m/s] 
+      [400~ m/s] 
       [Does not reload]
       Fires decoys when near the target to confuse point defense.
 	 </Description>

--- a/REEECore/Data/CubeBlocks_SC_Modular.sbc
+++ b/REEECore/Data/CubeBlocks_SC_Modular.sbc
@@ -11,7 +11,7 @@
      <DisplayName>LRM-5 Modular Launcher</DisplayName>
 	  <Description>
       [10km Targeting Range]
-      [850 m/s]
+      [510 m/s]
       [Energy Damage]
       [Does not reload]
       [5 Missiles]
@@ -65,7 +65,7 @@
      </Id>
      <DisplayName>LRM-5 Modular Launcher Middle</DisplayName>
 	  <Description>[10km Targeting Range]
-    [650 m/s]
+    [390 m/s]
     [Energy Damage]
     [Does not reload]
     [5 Missiles]
@@ -109,7 +109,7 @@
      </Id>
      <DisplayName>LRM-5 Modular Launcher 45</DisplayName>
 	  <Description>[10km Targeting Range]
-    [650 m/s]
+    [390 m/s]
     [Energy Damage]
     [Does not reload]
     [5 Missiles]
@@ -154,7 +154,7 @@
      </Id>
      <DisplayName>LRM-5 Modular Launcher 45 Reversed</DisplayName>
       <Description>[10km Targeting Range]
-    [650 m/s]
+    [390 m/s]
     [Energy Damage]
     [Does not reload]
     [5 Missiles]
@@ -200,7 +200,7 @@
      <DisplayName>MRM-10 Modular Launcher</DisplayName>
 	  <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -257,7 +257,7 @@
      <DisplayName>MRM-10 Modular Launcher Middle</DisplayName>
 	  <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -314,7 +314,7 @@
      <DisplayName>MRM-10 Modular Launcher 45</DisplayName>
       <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -360,7 +360,7 @@
      <DisplayName>MRM-10 Modular Launcher 45 Reversed</DisplayName>
       <Description>
     [5km Max Range, 3.5km Optimal Range]
-    [350~ m/s]
+    [390~ m/s]
     [Kinetic Damage]
     [Does not reload]
     [10 Missiles]
@@ -404,7 +404,7 @@
      </Id>
      <DisplayName>SRM-8</DisplayName>
 	  <Description>[3.5km Range]
-    [700~ m/s]
+    [420~ m/s]
     [Energy Damage]
     [Does not reload]
     Effective against armor, shields and modules.

--- a/REEECore/Data/Cubeblocks_ERPPC.sbc
+++ b/REEECore/Data/Cubeblocks_ERPPC.sbc
@@ -13,6 +13,7 @@
       <Description>
         [5km Range]
         [2400 m/s]
+        [Magazine of 2]
         [Energy Damage]
         [Draws ~250mw]
 

--- a/REEECore/Data/Cubeblocks_SC_E.sbc
+++ b/REEECore/Data/Cubeblocks_SC_E.sbc
@@ -14,7 +14,7 @@
       <Description>
         [20km max range]
         [Energy damage]
-        [800~ m/s]
+        [480~ m/s]
         [Reloads 6 times]
       </Description>
       <Icon>Textures\Icons\MCRNHeavy.png</Icon>
@@ -70,7 +70,7 @@
       <Description>
         [12km max range]
         [Energy damage]
-        [800~ m/s]
+        [480~ m/s]
         [Reloads 4 times]
         Effective against most targets, more vulnerable to point defense than other launchers.
       </Description>

--- a/REEECore/Data/Scripts/CoreParts/E_Starcore_MCRN_Heavy_Ammo.cs
+++ b/REEECore/Data/Scripts/CoreParts/E_Starcore_MCRN_Heavy_Ammo.cs
@@ -645,7 +645,7 @@ namespace Scripts
                 TargetLossTime = 0 , // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400 , // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 300f ,
-                DesiredSpeed = 800 , // voxel phasing if you go above 5100
+                DesiredSpeed = 480 , // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f ,
                 DeaccelTime = 0 , // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f , // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1034,7 +1034,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 800f,
-                DesiredSpeed = 600, // voxel phasing if you go above 5100
+                DesiredSpeed = 360, // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1403,7 +1403,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 100,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/REEECore/Data/Scripts/CoreParts/E_Starcore_UNN_Heavy_Ammo.cs
+++ b/REEECore/Data/Scripts/CoreParts/E_Starcore_UNN_Heavy_Ammo.cs
@@ -644,7 +644,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 300f,
-                DesiredSpeed = 800, // voxel phasing if you go above 5100
+                DesiredSpeed = 480, // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1033,7 +1033,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 2400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 800f,
-                DesiredSpeed = 600, // voxel phasing if you go above 5100
+                DesiredSpeed = 360, // voxel phasing if you go above 5100
                 MaxTrajectory = 20000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1402,7 +1402,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 100,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/REEECore/Data/Scripts/CoreParts/STARCORE_Modular_LRM_Ammo.cs
+++ b/REEECore/Data/Scripts/CoreParts/STARCORE_Modular_LRM_Ammo.cs
@@ -678,7 +678,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 3400, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 245, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 850, // voxel phasing if you go above 5100
+                DesiredSpeed = 510, // voxel phasing if you go above 5100
                 MaxTrajectory = 15000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/REEECore/Data/Scripts/CoreParts/STARCORE_Modular_MRM_Ammo.cs
+++ b/REEECore/Data/Scripts/CoreParts/STARCORE_Modular_MRM_Ammo.cs
@@ -290,7 +290,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 120, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 2670, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 900, // voxel phasing if you go above 5100
+                DesiredSpeed = 540, // voxel phasing if you go above 5100
                 MaxTrajectory = 7000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -715,7 +715,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 900, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 900, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 1000, // voxel phasing if you go above 5100
+                DesiredSpeed = 600, // voxel phasing if you go above 5100
                 MaxTrajectory = 7000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1129,7 +1129,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 3300, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 450f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 850, // voxel phasing if you go above 5100
+                DesiredSpeed = 510, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1518,7 +1518,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 0, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 1800, // voxel phasing if you go above 5100
+                DesiredSpeed = 1080, // voxel phasing if you go above 5100
                 MaxTrajectory = 1000, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1899,7 +1899,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 0, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 3800, // voxel phasing if you go above 5100
+                DesiredSpeed = 2280, // voxel phasing if you go above 5100
                 MaxTrajectory = 100, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/REEECore/Data/Scripts/CoreParts/Starcore_Ammo_Arrow.cs
+++ b/REEECore/Data/Scripts/CoreParts/Starcore_Ammo_Arrow.cs
@@ -673,7 +673,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 8000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 110f,
-                DesiredSpeed = 670, // voxel phasing if you go above 5100
+                DesiredSpeed = 400, // voxel phasing if you go above 5100
                 MaxTrajectory = 45000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1071,7 +1071,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 8000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 420f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 670, // voxel phasing if you go above 5100
+                DesiredSpeed = 400, // voxel phasing if you go above 5100
                 MaxTrajectory = 45000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1398,7 +1398,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 1, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1250, // voxel phasing if you go above 5100
+                DesiredSpeed = 750, // voxel phasing if you go above 5100
                 MaxTrajectory = 16,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1789,7 +1789,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 560, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 475f,
-                DesiredSpeed = 675, // voxel phasing if you go above 5100
+                DesiredSpeed = 400, // voxel phasing if you go above 5100
                 MaxTrajectory = 3500,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0.75f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/REEECore/Data/Scripts/CoreParts/Starcore_SRM_Ammo.cs
+++ b/REEECore/Data/Scripts/CoreParts/Starcore_SRM_Ammo.cs
@@ -285,7 +285,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 30, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 1800, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 245, // voxel phasing if you go above 5100
+                DesiredSpeed = 147, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -700,7 +700,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 1900, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 550f, // Acceleration in Meters Per Second. Projectile starts on tick 0 at its parents (weapon/other projectiles) travel velocity.
-                DesiredSpeed = 650, // voxel phasing if you go above 5100
+                DesiredSpeed = 390, // voxel phasing if you go above 5100
                 MaxTrajectory = 7000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1092,7 +1092,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 0f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 9000, // voxel phasing if you go above 5100
+                DesiredSpeed = 5400, // voxel phasing if you go above 5100
                 MaxTrajectory = 15, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/StarCore Halo Craft/Data/Scripts/CoreParts/longswordammo.cs
+++ b/StarCore Halo Craft/Data/Scripts/CoreParts/longswordammo.cs
@@ -1597,7 +1597,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 8000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 110f,
-                DesiredSpeed = 3700, // voxel phasing if you go above 5100
+                DesiredSpeed = 2220, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f,
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
@@ -1995,7 +1995,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 500, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). Please have a value for this, It stops Bad things.
                 AccelPerSec = 110f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 3700, // voxel phasing if you go above 5100
+                DesiredSpeed = 2220, // voxel phasing if you go above 5100
                 MaxTrajectory = 4000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/Starcore-One-Shot/Data/Scripts/CoreParts/SA_MSI_ATMI_Ammo.cs
+++ b/Starcore-One-Shot/Data/Scripts/CoreParts/SA_MSI_ATMI_Ammo.cs
@@ -264,7 +264,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 60, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 0f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 500, // voxel phasing if you go above 5100
+                DesiredSpeed = 300, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -650,7 +650,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 480, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 350f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 700, // voxel phasing if you go above 5100
+                DesiredSpeed = 420, // voxel phasing if you go above 5100
                 MaxTrajectory = 11000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1036,7 +1036,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 350f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 700, // voxel phasing if you go above 5100
+                DesiredSpeed = 420, // voxel phasing if you go above 5100
                 MaxTrajectory = 9000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1422,7 +1422,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 60, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 0f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 700, // voxel phasing if you go above 5100
+                DesiredSpeed = 420, // voxel phasing if you go above 5100
                 MaxTrajectory = 11000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/Starcore-One-Shot/Data/Scripts/CoreParts/SA_MSI_Hunt_Ammo.cs
+++ b/Starcore-One-Shot/Data/Scripts/CoreParts/SA_MSI_Hunt_Ammo.cs
@@ -264,7 +264,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 60, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 0f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 500, // voxel phasing if you go above 5100
+                DesiredSpeed = 300, // voxel phasing if you go above 5100
                 MaxTrajectory = 10000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -650,7 +650,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 480, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 350f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 700, // voxel phasing if you go above 5100
+                DesiredSpeed = 420, // voxel phasing if you go above 5100
                 MaxTrajectory = 11000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1036,7 +1036,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 350f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 700, // voxel phasing if you go above 5100
+                DesiredSpeed = 420, // voxel phasing if you go above 5100
                 MaxTrajectory = 9000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.
@@ -1422,7 +1422,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 60, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..). time begins at 0 and time must EXCEED this value to trigger "time > maxValue". Please have a value for this, It stops Bad things.
                 AccelPerSec = 0f, // Meters Per Second. This is the spawning Speed of the Projectile, and used by turning.
-                DesiredSpeed = 700, // voxel phasing if you go above 5100
+                DesiredSpeed = 420, // voxel phasing if you go above 5100
                 MaxTrajectory = 11000f, // Max Distance the projectile or beam can Travel.
                 DeaccelTime = 0, // 0 is disabled, a value causes the projectile to come to rest overtime, (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable. Natural Gravity Only.

--- a/TIOStarcore-Dev/Data/Scripts/CoreParts/Type18_ammo.cs
+++ b/TIOStarcore-Dev/Data/Scripts/CoreParts/Type18_ammo.cs
@@ -46,7 +46,7 @@ namespace Scripts
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 12000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore-Dev/Data/Scripts/CoreParts/Type21_ammo.cs
+++ b/TIOStarcore-Dev/Data/Scripts/CoreParts/Type21_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 13000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore-Dev/Data/Scripts/CoreParts/Type24_ammo.cs
+++ b/TIOStarcore-Dev/Data/Scripts/CoreParts/Type24_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 14000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore-Dev/Data/Scripts/CoreParts/Type77_Railgun_ammo.cs
+++ b/TIOStarcore-Dev/Data/Scripts/CoreParts/Type77_Railgun_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = .5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 40000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore-Dev/Data/Scripts/CoreParts/Type78_Railgun_ammo.cs
+++ b/TIOStarcore-Dev/Data/Scripts/CoreParts/Type78_Railgun_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = .5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 45000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore-Dev/Data/Scripts/CoreParts/Type79_Railgun_ammo.cs
+++ b/TIOStarcore-Dev/Data/Scripts/CoreParts/Type79_Railgun_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = .5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 50000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore/Data/Scripts/CoreParts/Type18_Ammo.cs
+++ b/TIOStarcore/Data/Scripts/CoreParts/Type18_Ammo.cs
@@ -46,7 +46,7 @@ namespace Scripts
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 12000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore/Data/Scripts/CoreParts/Type21_Ammo.cs
+++ b/TIOStarcore/Data/Scripts/CoreParts/Type21_Ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 13000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore/Data/Scripts/CoreParts/Type24_ammo.cs
+++ b/TIOStarcore/Data/Scripts/CoreParts/Type24_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 14000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore/Data/Scripts/CoreParts/Type77_Railgun_ammo.cs
+++ b/TIOStarcore/Data/Scripts/CoreParts/Type77_Railgun_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = .5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 40000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore/Data/Scripts/CoreParts/Type78_Railgun_ammo.cs
+++ b/TIOStarcore/Data/Scripts/CoreParts/Type78_Railgun_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = .5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 45000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 

--- a/TIOStarcore/Data/Scripts/CoreParts/Type79_Railgun_ammo.cs
+++ b/TIOStarcore/Data/Scripts/CoreParts/Type79_Railgun_ammo.cs
@@ -45,7 +45,7 @@ namespace Scripts
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = .5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 50000f, // Direct damage; one steel plate is worth 100.
-            Mass = 250f, // In kilograms; how much force the impact will apply to the target.
+            Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 150000f, // Recoil. This is applied to the Parent Grid.
             DecayPerShot = 0f, // Damage to the firing weapon itself. 


### PR DESCRIPTION
- most missiles (tartarus, cocytus, LRM,MRM,SRM, UNN,MCRN,phaethon, arrows, arrows from longsword + slam, etc) are now 40% slower to compensate for reduced arena size and give PD more time to react
- modifier on vanilla railguns reduced; shield 8(!!) -> 5; component 2; 1
- old scroll-targeting max range put back to 17500 from 10000
- type 77/78/79 railguns given a bit of depression to match with the artilleries
- mirroring (should be) fixed on Onyx weapons
- S.I. fieldgen should no longer
- Mk1,2,3 HE damage patterns now act like HE and don't penetrate like a drill (pending)
- cataclysmic (magnetar) and mammon power draw on reload fixed
- you may need to replace them to get the update