### PR TITLE
Fixes to integrity

### DIFF
--- a/TaitMod_Fletcher_Dev/Data/CubeBlocks/105mmTwin.sbc
+++ b/TaitMod_Fletcher_Dev/Data/CubeBlocks/105mmTwin.sbc
@@ -21,14 +21,14 @@
 			<Model>Models\Cubes\large\105mmTwin.mwm</Model>
 			<DamageEffectName>Damage_WeapExpl_Damaged</DamageEffectName>
 			<Components>
-				<Component Subtype="SteelPlate" Count="4000" />
+				<Component Subtype="SteelPlate" Count="400" />
 				<Component Subtype="MetalGrid" Count="100" />
 				<Component Subtype="LargeTube" Count="200" />
 				<Component Subtype="Motor" Count="100" />
 				<Component Subtype="Computer" Count="150" />
 				<Component Subtype="Construction" Count="150" />
 				<Component Subtype="MetalGrid" Count="150" />
-				<Component Subtype="SteelPlate" Count="8000" />
+				<Component Subtype="SteelPlate" Count="800" />
 			</Components>
 			<CriticalComponent Subtype="Computer" Index="15"/>
 			<MountPoints>

--- a/TaitMod_Fletcher_Dev/Data/CubeBlocks/203Quad.sbc
+++ b/TaitMod_Fletcher_Dev/Data/CubeBlocks/203Quad.sbc
@@ -20,14 +20,14 @@
 			<ModelOffset x="0" y="0" z="0"/>
 			<Model>Models\203quad\Aziumuth.mwm</Model>
 			<Components>
-				<Component Subtype="SteelPlate" Count="8000" />
+				<Component Subtype="SteelPlate" Count="800" />
 				<Component Subtype="MetalGrid" Count="100" />
 				<Component Subtype="LargeTube" Count="200" />
 				<Component Subtype="Motor" Count="100" />
 				<Component Subtype="Computer" Count="100" />
 				<Component Subtype="Construction" Count="2000" />
 				<Component Subtype="MetalGrid" Count="200" />
-				<Component Subtype="SteelPlate" Count="16000" />
+				<Component Subtype="SteelPlate" Count="1600" />
 			</Components>
 			<CriticalComponent Subtype="Motor" Index="0" />
 			<MountPoints>

--- a/TaitMod_Fletcher_Dev/Data/CubeBlocks/203Twin.sbc
+++ b/TaitMod_Fletcher_Dev/Data/CubeBlocks/203Twin.sbc
@@ -20,14 +20,14 @@
 			<ModelOffset x="0" y="0" z="0"/>
 			<Model>Models\203mmTwin\203Base.mwm</Model>
 			<Components>
-				<Component Subtype="SteelPlate" Count="4000" />
+				<Component Subtype="SteelPlate" Count="400" />
 				<Component Subtype="MetalGrid" Count="100" />
 				<Component Subtype="LargeTube" Count="200" />
 				<Component Subtype="Motor" Count="100" />
 				<Component Subtype="Computer" Count="100" />
 				<Component Subtype="Construction" Count="2000" />
 				<Component Subtype="MetalGrid" Count="200" />
-				<Component Subtype="SteelPlate" Count="7000" />
+				<Component Subtype="SteelPlate" Count="2000" />
 			</Components>
 			<CriticalComponent Subtype="Motor" Index="0" />
 			<MountPoints>

--- a/TaitMod_Fletcher_Dev/Data/CubeBlocks/Mk25 Rangefinder.sbc
+++ b/TaitMod_Fletcher_Dev/Data/CubeBlocks/Mk25 Rangefinder.sbc
@@ -21,12 +21,12 @@
 			<Model>Models\Rangefinder\Mk25 Rangefinder.mwm</Model>
 			<UseModelIntersection>true</UseModelIntersection>
 			<Components>
-				<Component Subtype="SteelPlate" Count="4000" />
+				<Component Subtype="SteelPlate" Count="400" />
 				<Component Subtype="MetalGrid" Count="100" />
 				<Component Subtype="LargeTube" Count="200" />
 				<Component Subtype="Motor" Count="100" />
 				<Component Subtype="Computer" Count="100" />
-				<Component Subtype="Construction" Count="2000" />
+				<Component Subtype="Construction" Count="200" />
 				<Component Subtype="MetalGrid" Count="200" />
 				<Component Subtype="SteelPlate" Count="7000" />
 			</Components>

--- a/TaitMod_Fletcher_Dev/Data/CubeBlocks/TorpBarbette.sbc
+++ b/TaitMod_Fletcher_Dev/Data/CubeBlocks/TorpBarbette.sbc
@@ -17,14 +17,14 @@
 			<ModelOffset x="0" y="0" z="0"/>
 			<Model>Models\25inchquin\TorpBarbette.mwm</Model>
 			<Components>
-				<Component Subtype="SteelPlate" Count="15000" />
+				<Component Subtype="SteelPlate" Count="1500" />
 				<Component Subtype="MetalGrid" Count="100" />
 				<Component Subtype="LargeTube" Count="200" />
 				<Component Subtype="Motor" Count="100" />
 				<Component Subtype="Computer" Count="100" />
 				<Component Subtype="Construction" Count="2000" />
 				<Component Subtype="MetalGrid" Count="200" />
-				<Component Subtype="SteelPlate" Count="32000" />
+				<Component Subtype="SteelPlate" Count="3200" />
 			</Components>
 			<CriticalComponent Subtype="Motor" Index="0" />
 			<MountPoints>

--- a/TaitMod_Fletcher_Dev/Data/Cubeblocks.sbc
+++ b/TaitMod_Fletcher_Dev/Data/Cubeblocks.sbc
@@ -974,9 +974,9 @@
         <Component Subtype="LargeTube" Count="200" />
         <Component Subtype="Motor" Count="100" />
         <Component Subtype="Computer" Count="100" />
-        <Component Subtype="Construction" Count="2000" />
+        <Component Subtype="Construction" Count="1000" />
 		<Component Subtype="MetalGrid" Count="200" />
-        <Component Subtype="SteelPlate" Count="1600" />
+        <Component Subtype="SteelPlate" Count="800" />
       </Components>
       <CriticalComponent Subtype="Motor" Index="0" />
       <MountPoints>
@@ -1126,7 +1126,7 @@
         <Component Subtype="Computer" Count="100" />
         <Component Subtype="Construction" Count="200" />
 		<Component Subtype="MetalGrid" Count="200" />
-        <Component Subtype="SteelPlate" Count="1400" />
+        <Component Subtype="SteelPlate" Count="700" />
       </Components>
       <CriticalComponent Subtype="Motor" Index="0" />
       <MountPoints>
@@ -1199,7 +1199,7 @@
         <Component Subtype="Computer" Count="50" />
         <Component Subtype="Construction" Count="200" />
 		<Component Subtype="MetalGrid" Count="200" />
-        <Component Subtype="SteelPlate" Count="1500" />
+        <Component Subtype="SteelPlate" Count="750" />
       </Components>
       <CriticalComponent Subtype="Motor" Index="0" />
       <MountPoints>
@@ -1582,7 +1582,7 @@
         <Component Subtype="Computer" Count="100" />
         <Component Subtype="Construction" Count="200" />
 		<Component Subtype="MetalGrid" Count="300" />
-        <Component Subtype="SteelPlate" Count="1500" />
+        <Component Subtype="SteelPlate" Count="750" />
       </Components>
       <CriticalComponent Subtype="Motor" Index="0" />
       <MountPoints>
@@ -1662,7 +1662,7 @@
         <Component Subtype="Computer" Count="100" />
         <Component Subtype="Construction" Count="200" />
 		<Component Subtype="MetalGrid" Count="300" />
-        <Component Subtype="SteelPlate" Count="1500" />
+        <Component Subtype="SteelPlate" Count="750" />
       </Components>
       <CriticalComponent Subtype="Motor" Index="0" />
       <MountPoints>

--- a/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/25InchQuinTorpLaunch.cs
+++ b/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/25InchQuinTorpLaunch.cs
@@ -53,7 +53,7 @@ namespace Scripts {
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // Minimum radius of threat to engage.
                 MaximumDiameter = 0, // Maximum radius of threat to engage; 0 = unlimited.
-                MaxTargetDistance = 7000, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
+                MaxTargetDistance = 10000, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
                 MinTargetDistance = 0, // Minimum distance at which targets will be automatically shot at.
                 TopTargets = 4, // Maximum number of targets to randomize between; 0 = unlimited.
                 CycleTargets = 0, // Number of targets to "cycle" per acquire attempt.
@@ -154,11 +154,11 @@ namespace Scripts {
                 },
                 Loading = new LoadingDef
                 {
-                    RateOfFire = 3000, // Set this to 3600 for beam weapons. This is how fast your Gun fires.
+                    RateOfFire = 2500, // Set this to 3600 for beam weapons. This is how fast your Gun fires.
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 2700, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 1800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 5, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 1, // Heat generated per shot.


### PR DESCRIPTION
Fixes to integrity
Thanks nate for helping me vibe check the integrity of shit
150mm single mount: less integrity
150mm twin: less integrity
5 inch singles: less integrity
8 inch quad less integrity
8 inch twin less integrity
25 inch torpedos: (i thought these was 1 minute) but now buffed - 45 second reload to 30 second reload, AI targeting range extened from 7km to 10km
Torp launcher has also had its integirty nerfed.... 4 million is a FUCKING DIASTER
105mm less integrity
Rangefinder: less integrity
