### PR TITLE
Tigers did not, in fact, need a x8 shield mod.

### DIFF
--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/MA_Laser_CubeBlocks.sbc
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/MA_Laser_CubeBlocks.sbc
@@ -102,7 +102,7 @@
       <DisplayName>Gladius Heavy Laser</DisplayName>
       <Description>
         [3km Targeting Range]
-        [Draws ~550GW]
+        [Draws ~550MW]
         [Energy damage]
         [Hitscan]
       </Description>
@@ -197,7 +197,7 @@
         T1 Laser turret
         Role: Point defense, targets only guided, defends own grid
         Ammo: Energy
-        Range: 100% to 2500m, 10% at 3000m.
+        Range: 100% to 800m, 10% at 1200m.
         Made by AutoMcD Astronautical and CriegWarfare.
       </Description>
       <Icon>Textures\GUI\Icons\Cubes\MA_PDX.dds</Icon>
@@ -285,10 +285,10 @@
       </Id>
       <DisplayName>PDX Laser T2</DisplayName>
       <Description>
-        T2 laser turret.
-        Role: General, Point Defense, Targets only Smart, Defends Self and Allies
-        Ammo: Energy
-        Range: 100% to 3500m, 25% at 4000m.
+        [2km Targeting Range]
+        [Draws ~125MW]
+        [Energy damage]
+        [Hitscan]
         Made by AutoMcD Astronautical, CriegWarfare, Mike_Dude.
       </Description>
       <Icon>Textures\GUI\Icons\Cubes\MA_T2PDX.png</Icon>
@@ -572,7 +572,7 @@
       <DisplayName>T1 Gimbal Laser Armored</DisplayName>
       <Icon>Textures\Icons\MA_Gimbal_Laser_Armored.dds</Icon>
       <Description>
-        [2km Targeting Range]
+        [1.2km Targeting Range]
         [Draws ~25MW]
         [Energy damage]
         [Hitscan]
@@ -672,7 +672,7 @@
       <DisplayName>T1 Gimbal Laser Armored Slope</DisplayName>
       <Icon>Textures\Icons\MA_Gimbal_Laser_Armored_Slope.dds</Icon>
       <Description>
-        [2km Targeting Range]
+        [1.2km Targeting Range]
         [Draws ~25MW]
         [Energy damage]
         [Hitscan]
@@ -771,7 +771,7 @@
       <DisplayName>T1 Gimbal Laser Armored Slope 2</DisplayName>
       <Icon>Textures\Icons\MA_Gimbal_Laser_Armored_Slope2.dds</Icon>
       <Description>
-        [2km Targeting Range]
+        [1.2km Targeting Range]
         [Draws ~25MW]
         [Energy damage]
         [Hitscan]
@@ -869,7 +869,7 @@
       <DisplayName>T1 Gimbal Laser Armored Slope 45</DisplayName>
       <Icon>Textures\Icons\MA_Gimbal_Laser_Armored_Slope45.dds</Icon>
       <Description>
-        [2km Targeting Range]
+        [1.2km Targeting Range]
         [Draws ~25MW]
         [Energy damage]
         [Hitscan]
@@ -969,7 +969,7 @@
       <DisplayName>T1 Gimbal Laser</DisplayName>
       <Icon>Textures\Icons\MA_Gimbal_Laser.dds</Icon>
       <Description>
-        [2km Targeting Range]
+        [1.2km Targeting Range]
         [Draws ~25MW]
         [Energy damage]
         [Hitscan]

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/MA_WC_Particles.sbc
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/MA_WC_Particles.sbc
@@ -8957,7 +8957,7 @@
 			<DurationMin>30</DurationMin>
 			<DurationMax>30</DurationMax>
 			<DistanceMax>1000</DistanceMax>
-			<Loop>true</Loop>
+			<Loop>false</Loop>
 			<ParticleGenerations>
 				<ParticleGeneration Name="Lightning01Backup" Version="2">
 					<GenerationType>GPU</GenerationType>

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Blister_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Blister_Ammo.cs
@@ -118,7 +118,7 @@ namespace Scripts
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.
                 FallOff = new FallOffDef
                 {
-                    Distance = 2000f, // Distance at which damage begins falling off.
+                    Distance = 800f, // Distance at which damage begins falling off.
                     MinMultipler = 0.8f, // Value from 0.0001f to 1f where 0.1f would be a min damage of 10% of base damage.
                 },
                 Grids = new GridSizeDef
@@ -135,7 +135,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 1.5f, // Multiplier for damage against shields.
+                    Modifier = 2f, // Multiplier for damage against shields.
                     Type = Default, // Damage vs healing against shields; Default, Heal
                     BypassModifier = -1f, // If greater than zero, the percentage of damage that will penetrate the shield.
                 },
@@ -275,7 +275,7 @@ namespace Scripts
                 DesiredSpeed = 1500, // voxel phasing if you go above 5100
                 MaxTrajectory = 2000f,
                 //FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
-                GravityMultiplier = .7f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                GravityMultiplier = 5f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
                 RangeVariance = Random(start: 0, end: 50), // subtracts value from MaxTrajectory
                 MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T1.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T1.cs
@@ -60,7 +60,7 @@ namespace Scripts {
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // Minimum radius of threat to engage.
                 MaximumDiameter = 0, // Maximum radius of threat to engage; 0 = unlimited.
-                MaxTargetDistance = 0, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
+                MaxTargetDistance = 1200, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
                 MinTargetDistance = 0, // Minimum distance at which targets will be automatically shot at.
                 TopTargets = 24, // Maximum number of targets to randomize between; 0 = unlimited.
                 CycleTargets = 4, // Number of targets to "cycle" per acquire attempt.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T1_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T1_Ammo.cs
@@ -110,7 +110,7 @@ namespace Scripts
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.
                 FallOff = new FallOffDef
                 {
-                    Distance = 2500f, // Distance at which damage begins falling off.
+                    Distance = 800f, // Distance at which damage begins falling off.
                     MinMultipler = 0.1f, // Value from 0.0001f to 1f where 0.1f would be a min damage of 10% of base damage.
                 },
                 Grids = new GridSizeDef
@@ -266,7 +266,7 @@ namespace Scripts
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 30000, // voxel phasing if you go above 5100
-                MaxTrajectory = 2000f,
+                MaxTrajectory = 1200f,
                 //FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T1_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T1_Ammo.cs
@@ -35,7 +35,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_1", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 1f, //50MW Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 50f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply    to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T2_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T2_Ammo.cs
@@ -37,7 +37,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T2_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 0.417f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 0.417f, //100MW  //50MW 0.417 Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 120f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T3_Ammo.cs
@@ -38,7 +38,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T3_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 0.417f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 0.7f, //224MW  //0.417 133MW // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 320f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
@@ -436,7 +436,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_Gladius_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 0.7f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 0.7f, //448 Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 320f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
@@ -838,7 +838,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Ion_1", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 0.5f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 0.5f, //50MW Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 100f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T4_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Laser_T4_Ammo.cs
@@ -38,7 +38,7 @@ namespace Scripts
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "MA_Laser_T4_Ammo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 0.23125f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 0.23125f, //750MW Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = 640f, // Direct damage; one steel plate is worth 100.
             Mass = 0f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Tiger.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Tiger.cs
@@ -137,16 +137,17 @@ namespace Scripts {
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 340, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 350, //340 // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 1, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
-                    HeatPerShot = 14, // Heat generated per shot.
-                    MaxHeat = 300, // Max heat before weapon enters cooldown (70% of max heat).
-                    Cooldown = .6f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
-                    HeatSinkRate = 18, // Amount of heat lost per second.
+                    HeatPerShot = 14, //10 // Heat generated per shot.
+                    MaxHeat = 330, //400 // Max heat before weapon enters cooldown (70% of max heat).
+                    Cooldown = .55f, //0.6f // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
+                    HeatSinkRate = 15, //9 // Amount of heat lost per second.
+                    //40 delay, 350 reload, means it reaches exactly max heat after the 4th burst of the 3rd salvo, and not inbetween bursts, thus reloading when overheated.  0.55 heat cap means it can fire off 1 full salvo of 4 bursts before overheating again and not overheating mid salvo.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 4, // Use this if you don't want the weapon to fire an entire physical magazine before stopping to reload. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 25, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 40, //25 // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = true, // Whether the weapon should fire the full burst, even if the target is lost or player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Tiger.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Tiger.cs
@@ -328,16 +328,17 @@ namespace Scripts {
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 340, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 350, //340 // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 1, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
-                    HeatPerShot = 14, // Heat generated per shot.
-                    MaxHeat = 300, // Max heat before weapon enters cooldown (70% of max heat).
-                    Cooldown = .6f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
-                    HeatSinkRate = 18, // Amount of heat lost per second.
+                    HeatPerShot = 14, //10 // Heat generated per shot.
+                    MaxHeat = 330, //400 // Max heat before weapon enters cooldown (70% of max heat).
+                    Cooldown = .55f, //0.6f // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
+                    HeatSinkRate = 15, //9 // Amount of heat lost per second.
+                    //40 delay, 350 reload, means it reaches exactly max heat after the 4th burst of the 3rd salvo, and not inbetween bursts, thus reloading when overheated.  0.55 heat cap means it can fire off 1 full salvo of 4 bursts before overheating again and not overheating mid salvo.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 4, // Use this if you don't want the weapon to fire an entire physical magazine before stopping to reload. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 25, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 40, //25 // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = true, // Whether the weapon should fire the full burst, even if the target is lost or player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Tiger_Ammo.cs
+++ b/Weapon Mods/Stable/Starcore-MA-Weapons-Natemod/Data/Scripts/CoreParts/MA_Tiger_Ammo.cs
@@ -136,7 +136,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 8f, // it needs this
+                    Modifier = 3f, // it didnt need this
                     Type = Default, // Damage vs healing against shields; Default, Heal
                     BypassModifier = -1f, // If greater than zero, the percentage of damage that will penetrate the shield.
                 },


### PR DESCRIPTION
Reverting to the previous x3 shield mod, fixing some of the heat instead of dropping other damages.

Been shooting a wall a lot, noticed it kept stopping to overheat in the middle of bursts which I don't recall the automcd tiger doing.  Very Minor tweaks to heat and fire rate to prevent this, instead of 1 very big change to 1 stat.
40 delay, 350 reload, means it reaches max heat exactly after the 4th burst of the 3rd salvo, and not in-between bursts, thus reloading when overheated.  0.55 heat cap means it can fire off 1 full salvo of 4 bursts before overheating again and not overheating mid salvo.
(loads a 16 round clip, meaning that a full salvo means 4 bursts of 4 bullets each)

T1s are in?! Reducing range so they are not the same range of a T2 and better at PD than a much bigger T2 laser.

also:
Looping particles must perish.
