### PR TITLE
Fixing Weapons stuff in Ship Tracker + Charon tap

### DIFF
--- a/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/PointCheckHelpers.cs
+++ b/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/PointCheckHelpers.cs
@@ -302,17 +302,30 @@ internal static class PointCheckHelpers
 {"HAS_Crossfield", true},
 {"PriestReskin_Block", true},
 {"Reaver_Coilgun_Block",true },
-            { "Type18_Artillery_Block", true },
-            { "Type21_Artillery_Block", true },
-            { "Type24_Artillery_Block", true },
-            { "Type77_Railgun_Block", true },
-            { "Type78_Railgun_Block", true },
-            { "Type79_Railgun_Block", true },
-            {"MA_Blister",true },
-            {"MA_Blister45",true },
-            {"MA_Blister30",true },
-            {"MA_Blister32",true },
-            {"MA_Meatball",true },
+{"Type18_Artillery", true },
+{"Type21_Artillery", true },
+{"Type24_Artillery", true },
+{"Type19_Driver", true },
+{"Type22_Driver", true },
+{"Type25_Driver", true },
+{"MA_Blister",true },
+{"MA_Blister45",true },
+{"MA_Blister30",true },
+{"MA_Blister32",true },
+{"MA_Meatball",true },
+{"X4_7x7_HeavyTurret",true}
+{"VindicatorKineticLance",true}
+{"DualSnubLaserTurret",true}
+{"DualPulseLaserTurret",true}
+{"GoalieCasemate",true}
+{"HadeanPlasmaBlastgun",true}
+{"DrunkRocketTurret",true}
+{"KreegMagnetarCannon",true}
+{"HeavyFighterBay",true}
+{"Thagomizer",true}
+{"HeavyCarronade_5x5_Turret",true}
+{"UnguidedRocketTurret",true}
+{"NavalHeavyGaussRifle",true}
 };
     public static bool NameplateVisible = true; public static int timer = 0;
 }

--- a/Weapon Mods/Stable/Starcore_Serpent_Arms_Heavy_Metal/Data/Scripts/CoreParts/Charon.cs
+++ b/Weapon Mods/Stable/Starcore_Serpent_Arms_Heavy_Metal/Data/Scripts/CoreParts/Charon.cs
@@ -101,7 +101,7 @@ namespace Scripts {
                     HomeAzimuth = 0, // Default resting rotation angle
                     HomeElevation = 0, // Default resting elevation
                     InventorySize = 1f, // Inventory capacity in kL.
-                    IdlePower = 1f, // Constant base power draw in MW.
+                    IdlePower = 100f, // Constant base power draw in MW.
                     FixedOffset = false, // Deprecated.
                     Offset = Vector(x: 0, y: 0, z: 0), // Offsets the aiming/firing line of the weapon, in metres.
                     Type = BlockWeapon, // What type of weapon this is; BlockWeapon, HandWeapon, Phantom 


### PR DESCRIPTION
Adding new weapons to the tracker so they show up as Weapons on the Shift+T.

Also, giving Charon a 100 MW idle power draw.