### PR TITLE
Damage Buff

### DIFF
--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/105mm SAP.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/105mm SAP.cs
@@ -36,7 +36,7 @@ namespace Scripts
             AmmoRound = "105mm SAP", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 800f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 1200f, // Direct damage; one steel plate is worth 100.
             Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 5f, // Recoil. This is applied to the Parent Grid.
@@ -393,7 +393,7 @@ namespace Scripts
             AmmoRound = "5InchSapShrap", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 300f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 450f, // Direct damage; one steel plate is worth 100.
             Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50000f, // Recoil. This is applied to the Parent Grid.

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/127mm SAP Shell.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/127mm SAP Shell.cs
@@ -36,7 +36,7 @@ namespace Scripts
             AmmoRound = "5-InchSAP", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 3500f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 5250f, // Direct damage; one steel plate is worth 100.
             Mass = 100f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 5f, // Recoil. This is applied to the Parent Grid.
@@ -393,7 +393,7 @@ namespace Scripts
             AmmoRound = "5InchSapShrap", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 400f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 500f, // Direct damage; one steel plate is worth 100.
             Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 5f, // Recoil. This is applied to the Parent Grid.

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/127mm Shell.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/127mm Shell.cs
@@ -36,7 +36,7 @@ namespace Scripts
             AmmoRound = "5-InchHE", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 100f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 1f, // Direct damage; one steel plate is worth 100.
             Mass = 10f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 5f, // Recoil. This is applied to the Parent Grid.
@@ -393,7 +393,7 @@ namespace Scripts
             AmmoRound = "5InchShrap", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 500f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 1000f, // Direct damage; one steel plate is worth 100.
             Mass = 100f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50000f, // Recoil. This is applied to the Parent Grid.

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/150mmHE.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/150mmHE.cs
@@ -394,7 +394,7 @@ namespace Scripts
             AmmoRound = "15CmShrap", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 400f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 1200f, // Direct damage; one steel plate is worth 100.
             Mass = 1f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50000f, // Recoil. This is applied to the Parent Grid.

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/152mmAP.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/152mmAP.cs
@@ -36,7 +36,7 @@ namespace Scripts
             AmmoRound = "6-InchAP", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 3000f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 4500f, // Direct damage; one steel plate is worth 100.
             Mass = 100f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50f, // Recoil. This is applied to the Parent Grid.

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/203mm AP.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/203mm AP.cs
@@ -36,7 +36,7 @@ namespace Scripts
             AmmoRound = "8InchAP", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 10000f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 15000f, // Direct damage; one steel plate is worth 100.
             Mass = 100f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50f, // Recoil. This is applied to the Parent Grid.
@@ -141,7 +141,7 @@ namespace Scripts
                 {
                     Enable = true,
                     Radius = 5f, // Meters
-                    Damage = 5f,
+                    Damage = 7500f,
                     Depth = 1f, // Meters
                     MaxAbsorb = 0f,
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/380mm AP Shell.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/380mm AP Shell.cs
@@ -36,7 +36,7 @@ namespace Scripts
             AmmoRound = "380mmAP", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 20000f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 30000f, // Direct damage; one steel plate is worth 100.
             Mass = 100f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50f, // Recoil. This is applied to the Parent Grid.
@@ -155,7 +155,7 @@ namespace Scripts
                 {
                     Enable = true,
                     Radius = 1.5f,
-                    Damage = 4500f,
+                    Damage = 6750f,
                     Depth = 5f,
                     MaxAbsorb = 0f,
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/380mm HE Shell.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/380mm HE Shell.cs
@@ -392,7 +392,7 @@ namespace Scripts
             AmmoRound = "380mmShrap", // Name of ammo in terminal, should be different for each ammo type used by the same weapon. Is used by Shrapnel.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0.1f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = 2500f, // Direct damage; one steel plate is worth 100.
+            BaseDamage = 5000f, // Direct damage; one steel plate is worth 100.
             Mass = 100f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
             BackKickForce = 50000f, // Recoil. This is applied to the Parent Grid.

--- a/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/508SAP.cs
+++ b/Weapon Mods/Development/TaitMod_Fletcher_Dev/Data/Scripts/CoreParts/508SAP.cs
@@ -156,7 +156,7 @@ namespace Scripts
                 {
                     Enable = true,
                     Radius = 7f,
-                    Damage = 12000,
+                    Damage = 24000,
                     Depth = 3.5f,
                     MaxAbsorb = 0f,
                     Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius


### PR DESCRIPTION
Damage has been buffed ALMOST accross the board by 50% a few guns missed this due to them already performing well



Damage accross the board increased by 50% for offensive weapons (barring torpedos, the doom tubes are the same)
20 inch AP and HE untouched