### PR TITLE
Abolished weight watchers

### DIFF
--- a/Weapon Mods/Stable/StarCore Homeworld Craft/Data/Cubeblocks_HW.sbc
+++ b/Weapon Mods/Stable/StarCore Homeworld Craft/Data/Cubeblocks_HW.sbc
@@ -27,15 +27,16 @@
 			<ModelOffset x="0" y="0" z="0"/>
 			<Model>Models\LaunchRail.mwm</Model>
 			<Components>
-				<Component Subtype="SteelPlate" Count="6000" />
+				<Component Subtype="SteelPlate" Count="7000" />
                 <Component Subtype="Construction" Count="400" />
-								<Component Subtype="SmallTube" Count="80" />
+				<Component Subtype="SmallTube" Count="80" />
                 <Component Subtype="Motor" Count="150" />
                 <Component Subtype="LargeTube" Count="80" />
                 <Component Subtype="Computer" Count="60" />
+				<Component Subtype="GravityGenerator" Count="300" />
                 <Component Subtype="InteriorPlate" Count="120" />
                 <Component Subtype="Construction" Count="140" />
-                <Component Subtype="SteelPlate" Count="2000" />
+                <Component Subtype="SteelPlate" Count="5000" />
 			</Components>
 			<CriticalComponent Index="0" Subtype="Computer"/>
 			<MountPoints>
@@ -109,17 +110,18 @@
       <Size x="3" y="7" z="30"/>
       <ModelOffset x="0" y="0" z="0"/>
       <Model>Models\LaunchRail.mwm</Model>
-      <Components>
-        <Component Subtype="SteelPlate" Count="6000" />
-        <Component Subtype="Construction" Count="400" />
-        <Component Subtype="SmallTube" Count="80" />
-        <Component Subtype="Motor" Count="150" />
-        <Component Subtype="LargeTube" Count="80" />
-        <Component Subtype="Computer" Count="60" />
-        <Component Subtype="InteriorPlate" Count="120" />
-        <Component Subtype="Construction" Count="140" />
-        <Component Subtype="SteelPlate" Count="2000" />
-      </Components>
+		<Components>
+			<Component Subtype="SteelPlate" Count="7000" />
+			<Component Subtype="Construction" Count="400" />
+			<Component Subtype="SmallTube" Count="80" />
+			<Component Subtype="Motor" Count="150" />
+			<Component Subtype="LargeTube" Count="80" />
+			<Component Subtype="Computer" Count="60" />
+			<Component Subtype="GravityGenerator" Count="300" />
+			<Component Subtype="InteriorPlate" Count="120" />
+			<Component Subtype="Construction" Count="140" />
+			<Component Subtype="SteelPlate" Count="5000" />
+		</Components>
       <CriticalComponent Index="0" Subtype="Computer"/>
       <MountPoints>
         <MountPoint Side="Bottom" StartX="0" StartY="0.00" EndX="3" EndY="30"/>
@@ -193,15 +195,16 @@
 			<ModelOffset x="0" y="0" z="0"/>
 			<Model>Models\HomeworldHangarBlock.mwm</Model>
 			<Components>
-				<Component Subtype="SteelPlate" Count="2000" />
-                <Component Subtype="Construction" Count="820" />
-								<Component Subtype="SmallTube" Count="160" />
-                <Component Subtype="Motor" Count="300" />
-                <Component Subtype="LargeTube" Count="160" />
-                <Component Subtype="Computer" Count="120" />
-                <Component Subtype="InteriorPlate" Count="240" />
-                <Component Subtype="Construction" Count="280" />
-                <Component Subtype="SteelPlate" Count="4000" />
+				<Component Subtype="SteelPlate" Count="5000" />
+				<Component Subtype="Construction" Count="400" />
+				<Component Subtype="SmallTube" Count="80" />
+				<Component Subtype="Motor" Count="150" />
+				<Component Subtype="LargeTube" Count="80" />
+				<Component Subtype="Computer" Count="60" />
+				<Component Subtype="GravityGenerator" Count="300" />
+				<Component Subtype="InteriorPlate" Count="120" />
+				<Component Subtype="Construction" Count="140" />
+				<Component Subtype="SteelPlate" Count="4000" />
 			</Components>
 			<CriticalComponent Index="0" Subtype="Computer"/>
 			<MountPoints>
@@ -283,17 +286,18 @@
       <Size x="13" y="5" z="7"/>
       <ModelOffset x="0" y="0" z="0"/>
       <Model>Models\HomeworldHangarBlockThin.mwm</Model>
-      <Components>
-        <Component Subtype="SteelPlate" Count="2000" />
-        <Component Subtype="Construction" Count="820" />
-        <Component Subtype="SmallTube" Count="160" />
-        <Component Subtype="Motor" Count="300" />
-        <Component Subtype="LargeTube" Count="160" />
-        <Component Subtype="Computer" Count="120" />
-        <Component Subtype="InteriorPlate" Count="240" />
-        <Component Subtype="Construction" Count="280" />
-        <Component Subtype="SteelPlate" Count="4000" />
-      </Components>
+		<Components>
+			<Component Subtype="SteelPlate" Count="5000" />
+			<Component Subtype="Construction" Count="400" />
+			<Component Subtype="SmallTube" Count="80" />
+			<Component Subtype="Motor" Count="150" />
+			<Component Subtype="LargeTube" Count="80" />
+			<Component Subtype="Computer" Count="60" />
+			<Component Subtype="GravityGenerator" Count="300" />
+			<Component Subtype="InteriorPlate" Count="120" />
+			<Component Subtype="Construction" Count="140" />
+			<Component Subtype="SteelPlate" Count="4000" />
+		</Components>
       <CriticalComponent Index="0" Subtype="Computer"/>
       <MountPoints>
         <MountPoint Side="Top" StartX="0" StartY="0" EndX="13" EndY="7" />
@@ -375,17 +379,18 @@
       <Size x="13" y="5" z="17"/>
       <ModelOffset x="0" y="0" z="0"/>
       <Model>Models\HomeworldHangarBlock.mwm</Model>
-      <Components>
-        <Component Subtype="SteelPlate" Count="2000" />
-        <Component Subtype="Construction" Count="820" />
-        <Component Subtype="SmallTube" Count="160" />
-        <Component Subtype="Motor" Count="300" />
-        <Component Subtype="LargeTube" Count="160" />
-        <Component Subtype="Computer" Count="120" />
-        <Component Subtype="InteriorPlate" Count="240" />
-        <Component Subtype="Construction" Count="280" />
-        <Component Subtype="SteelPlate" Count="4000" />
-      </Components>
+		<Components>
+			<Component Subtype="SteelPlate" Count="5000" />
+			<Component Subtype="Construction" Count="400" />
+			<Component Subtype="SmallTube" Count="80" />
+			<Component Subtype="Motor" Count="150" />
+			<Component Subtype="LargeTube" Count="80" />
+			<Component Subtype="Computer" Count="60" />
+			<Component Subtype="GravityGenerator" Count="300" />
+			<Component Subtype="InteriorPlate" Count="120" />
+			<Component Subtype="Construction" Count="140" />
+			<Component Subtype="SteelPlate" Count="4000" />
+		</Components>
       <CriticalComponent Index="0" Subtype="Computer"/>
       <MountPoints>
         <MountPoint Side="Top" StartX="0" StartY="0" EndX="13" EndY="17" />
@@ -467,17 +472,18 @@
       <Size x="5" y="5" z="7"/>
       <ModelOffset x="0" y="0" z="0"/>
       <Model>Models\SingleHangar.mwm</Model>
-      <Components>
-        <Component Subtype="SteelPlate" Count="500" />
-        <Component Subtype="Construction" Count="820" />
-        <Component Subtype="SmallTube" Count="160" />
-        <Component Subtype="Motor" Count="300" />
-        <Component Subtype="LargeTube" Count="160" />
-        <Component Subtype="Computer" Count="120" />
-        <Component Subtype="InteriorPlate" Count="240" />
-        <Component Subtype="Construction" Count="280" />
-        <Component Subtype="SteelPlate" Count="1000" />
-      </Components>
+		<Components>
+			<Component Subtype="SteelPlate" Count="1000" />
+			<Component Subtype="Construction" Count="400" />
+			<Component Subtype="SmallTube" Count="80" />
+			<Component Subtype="Motor" Count="150" />
+			<Component Subtype="LargeTube" Count="80" />
+			<Component Subtype="Computer" Count="60" />
+			<Component Subtype="GravityGenerator" Count="250" />
+			<Component Subtype="InteriorPlate" Count="120" />
+			<Component Subtype="Construction" Count="140" />
+			<Component Subtype="SteelPlate" Count="950" />
+		</Components>
       <CriticalComponent Index="0" Subtype="Computer"/>
       <MountPoints>
         <MountPoint Side="Bottom" StartX="0" StartY="0" EndX="5" EndY="7" />

--- a/Weapon Mods/Stable/StarCore Homeworld Craft/Data/Scripts/CoreParts/Taiidan.cs
+++ b/Weapon Mods/Stable/StarCore Homeworld Craft/Data/Scripts/CoreParts/Taiidan.cs
@@ -25,7 +25,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
                     
@@ -247,7 +247,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 
@@ -470,7 +470,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 
@@ -692,7 +692,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 
@@ -914,7 +914,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 
@@ -1138,7 +1138,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 
@@ -1361,7 +1361,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 
@@ -1583,7 +1583,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located. This is often the elevation subpart. Subpart_Boomsticks must be written as Boomsticks.
                         AzimuthPartId = "None", // Your Rotating Subpart, the bit that moves sideways.
                         ElevationPartId = "None",// Your Elevating Subpart, that bit that moves up.
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
 


### PR DESCRIPTION
- Nerfing all Taiidan fighter/bomber blocks
> DurabilityMod: .15 -> .25
> Massive component changes to get relative durability back near the values they previously had, just heavier.