### PR TITLE
Fusion System Nerf

### DIFF
--- a/Gamemode Mods/Stable/Starcore_Pointslist/Data/Scripts/Additions/PointAdditions.cs
+++ b/Gamemode Mods/Stable/Starcore_Pointslist/Data/Scripts/Additions/PointAdditions.cs
@@ -645,7 +645,7 @@ Cat_UnusedOrOutated_Subtypes@23;
 
 
 				Caster_Accelerator_0@5;
-				Caster_Accelerator_90@10;
+				Caster_Accelerator_90@20;
 				Caster_Feeder@10;
 				Caster_FocusLens@50;
 				Caster_Reactor@250;

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionReactor/FusionReactorLogic.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionReactor/FusionReactorLogic.cs
@@ -32,7 +32,7 @@ namespace MoA_Fusion_Systems.Data.Scripts.ModularAssemblies.
             var powerConsumption = PowerGeneration * 60 * reactorConsumptionMultiplier;
 
 
-            var reactorEfficiencyMultiplier = 1 / (0.5f + reactorConsumptionMultiplier);
+            var reactorEfficiencyMultiplier = 1 / (0.25f + reactorConsumptionMultiplier);
             // Power generated (per second)
             var reactorOutput = reactorEfficiencyMultiplier * powerConsumption * MegawattsPerFusionPower;
 

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionThruster/FusionThrusterLogic.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionThruster/FusionThrusterLogic.cs
@@ -24,7 +24,7 @@ namespace MoA_Fusion_Systems.Data.Scripts.ModularAssemblies.FusionParts.FusionTh
                 OverrideEnabled.Value
                     ? OverridePowerUsageSync
                     : PowerUsageSync.Value; // This is ugly, let's make it better.
-            var efficiencyMultiplier = 1 / (0.5f + consumptionMultiplier);
+            var efficiencyMultiplier = 1 / (0.25f + consumptionMultiplier);
 
             // Power generation consumed (per second)
             var powerConsumption = PowerGeneration * 60 * consumptionMultiplier;

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/S_FusionArm.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/S_FusionArm.cs
@@ -13,9 +13,9 @@ namespace MoA_Fusion_Systems.Data.Scripts.ModularAssemblies.
     /// </summary>
     internal struct S_FusionArm
     {
-        private const float LengthEfficiencyModifier = 1 / 40f;
-        private const float BlockPowerGeneration = 0.005f;
-        private const float BlockPowerStorage = 2f;
+        private const float LengthEfficiencyModifier = 0.05f;
+        private const float BlockPowerGeneration = 0.01f;
+        private const float BlockPowerStorage = 4f;
 
         private static ModularDefinitionAPI ModularAPI => ModularDefinition.ModularAPI;
 

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/S_FusionSystem.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/S_FusionSystem.cs
@@ -12,7 +12,7 @@ namespace MoA_Fusion_Systems.Data.Scripts.ModularAssemblies.
 {
     internal class S_FusionSystem
     {
-        public const float MegawattsPerFusionPower = 85;
+        public const float MegawattsPerFusionPower = 30;
         public const float NewtonsPerFusionPower = 3200000;
 
         public List<S_FusionArm> Arms = new List<S_FusionArm>();


### PR DESCRIPTION
- Caster Accelerator 90: 10bp -> 20bp
- Caster Accelerator 90: 0.3FP/s -> 0.6FP/s
- Caster Accelerator 0: 2FP stored -> 4FP stored
- Caster Reactor 0: MegawattsPerFusionPower: 85 -> 35

- ConsumerEfficiencyOffset: 0.5 -> 0.25
- LengthEfficiencyModifier: 0.025 -> 0.05

The TLDR of these changes is that fusion's MW/BP is significantly decreased (from 2-3 to 1.2ish for a 'typical' system).
However, the number of accelerator blocks for a given amount of power generation (and storage) has also been cut in half.