### PR TITLE
fix infinite loop of ??? in paperoll that also caused a memory leak

### DIFF
--- a/Utility Mods/Stable/PaperDoll/Data/Scripts/Visual/Visual.cs
+++ b/Utility Mods/Stable/PaperDoll/Data/Scripts/Visual/Visual.cs
@@ -890,7 +890,7 @@ namespace klime.Visual
 
         private void UpdateRealLogic()
         {
-            if (realGrid?.MarkedForClose == true || realGrid?.Physics == null || !realGrid.IsPowered ) Close();
+            if (realGrid?.MarkedForClose == true || realGrid?.Physics == null) Close();
         }
 
         public void Close()


### PR DESCRIPTION
when you targeted a grid that was depowered and tried to render a paperdoll of it for the first time you'd get an infinitely climbing memory leak for...some reason. this just removed a power check that was in there. Can't remember why. relic of the past?