### PR TITLE
Arc Emitter Nerf

### DIFF
--- a/Weapon Mods/Stable/AMP-Aristeas-Melee-Pack/Data/Scripts/CoreParts/AMP_ArcAmmo.cs
+++ b/Weapon Mods/Stable/AMP-Aristeas-Melee-Pack/Data/Scripts/CoreParts/AMP_ArcAmmo.cs
@@ -123,7 +123,7 @@ namespace Scripts
                     Armor = 0.8f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = 0.5f, // Multiplier for damage against light armor.
                     Heavy = 0.35f, // Multiplier for damage against heavy armor.
-                    NonArmor = -1f, // Multiplier for damage against every else.
+                    NonArmor = 0.5f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {

--- a/Weapon Mods/Stable/AMP-Aristeas-Melee-Pack/Data/Scripts/CoreParts/AMP_ArcMelee.cs
+++ b/Weapon Mods/Stable/AMP-Aristeas-Melee-Pack/Data/Scripts/CoreParts/AMP_ArcMelee.cs
@@ -125,9 +125,9 @@ namespace Scripts
                     ReloadTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 1, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
-                    HeatPerShot = 5, // Heat generated per shot.
+                    HeatPerShot = 6, // Heat generated per shot.
                     MaxHeat = 5400, // Max heat before weapon enters cooldown (70% of max heat).
-                    Cooldown = 0.95f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
+                    Cooldown = 0f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
                     HeatSinkRate = 120, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 0, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.

--- a/Weapon Mods/Stable/AMP-Aristeas-Melee-Pack/Data/Scripts/CoreParts/AMP_ArcMeleeReskin.cs
+++ b/Weapon Mods/Stable/AMP-Aristeas-Melee-Pack/Data/Scripts/CoreParts/AMP_ArcMeleeReskin.cs
@@ -125,9 +125,9 @@ namespace Scripts
                     ReloadTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 1, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
-                    HeatPerShot = 5, // Heat generated per shot.
+                    HeatPerShot = 6, // Heat generated per shot.
                     MaxHeat = 5400, // Max heat before weapon enters cooldown (70% of max heat).
-                    Cooldown = 0.95f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
+                    Cooldown = 0f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95
                     HeatSinkRate = 120, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 0, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.


### PR DESCRIPTION
- 15 second overheat, 45 second cooldown
- 0.5x component damage modifier
- Enforced full cooldown