### PR TITLE
ShareTrack and TDM Dev

### DIFF
--- a/Gamemode Mods/Stable/StarCore SUGMA Gamemodes/Data/Scripts/SUGMA/SUtils.cs
+++ b/Gamemode Mods/Stable/StarCore SUGMA Gamemodes/Data/Scripts/SUGMA/SUtils.cs
@@ -16,7 +16,7 @@ namespace SC.SUGMA
 
         public static void SetDamageEnabled(bool value)
         {
-            MyAPIGateway.Utilities.ShowMessage("SUGMA", $"Global damage {(value ? "enabled" : "disabled")}.");
+            //MyAPIGateway.Utilities.ShowMessage("SUGMA", $"Global damage {(value ? "enabled" : "disabled")}.");
 
             int existing = (int)MySessionComponentSafeZones.AllowedActions;
             MySessionComponentSafeZones.AllowedActions = CastProhibit(MySessionComponentSafeZones.AllowedActions,
@@ -25,8 +25,8 @@ namespace SC.SUGMA
 
         public static void SetWorldPermissionsForMatch(bool matchActive)
         {
-            MyAPIGateway.Utilities.ShowMessage("SUGMA",
-                $"Match global permissions {(matchActive ? "enabled" : "disabled")}.");
+            //MyAPIGateway.Utilities.ShowMessage("SUGMA",
+            //    $"Match global permissions {(matchActive ? "enabled" : "disabled")}.");
 
             MySessionComponentSafeZones.AllowedActions = CastProhibit(MySessionComponentSafeZones.AllowedActions,
                 matchActive ? MatchPermsInt : FullPermsInt);

--- a/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/HeartNetworking/Custom/ShieldFillRequestPacket.cs
+++ b/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/HeartNetworking/Custom/ShieldFillRequestPacket.cs
@@ -1,4 +1,5 @@
-﻿using Sandbox.Game.Entities;
+﻿using ProtoBuf;
+using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using ShipPoints;
 using ShipPoints.HeartNetworking;
@@ -6,6 +7,7 @@ using ShipPoints.HeartNetworking;
 namespace SCModRepository_Dev.Gamemode_Mods.Development.Starcore_Sharetrack_Dev.Data.Scripts.ShipPoints.HeartNetworking.
     Custom
 {
+    [ProtoContract]
     internal class ShieldFillRequestPacket : PacketBase
     {
         public override void Received(ulong SenderSteamId)

--- a/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracking/GridStats.cs
+++ b/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracking/GridStats.cs
@@ -42,6 +42,7 @@ namespace ShipPoints.ShipTracking
 
             Grid.OnBlockAdded += OnBlockAdd;
             Grid.OnBlockRemoved += OnBlockRemove;
+            Grid.OnGridBlockDamaged += OnBlockDamage;
             Update();
         }
 
@@ -49,6 +50,7 @@ namespace ShipPoints.ShipTracking
         {
             Grid.OnBlockAdded -= OnBlockAdd;
             Grid.OnBlockRemoved -= OnBlockRemove;
+            Grid.OnGridBlockDamaged -= OnBlockDamage;
 
             _slimBlocks.Clear();
             _fatBlocks.Clear();
@@ -135,6 +137,11 @@ namespace ShipPoints.ShipTracking
             GridIntegrity -= block.Integrity;
 
             NeedsUpdate = true;
+        }
+
+        private void OnBlockDamage(IMySlimBlock block, float damage, MyHitInfo? hitInfo, long attacker)
+        {
+            GridIntegrity -= damage;
         }
 
         #endregion


### PR DESCRIPTION
[Improved granularity of ship integrity tracker](https://github.com/StarCoreSE/SCModRepository/commit/7e0142e5af497486c2a284afc64bd9c1b0417341) - Ship HP is now updated as blocks take damage, rather than as they are destroyed.
[TDM - Grids can now be "revived" if welded back to functional](https://github.com/StarCoreSE/SCModRepository/commit/baa1309554feca046594264110a90af32d4b2654) - Fixes an edge case where killing the same ship twice removes its tickets twice.

There's also a theoretical fix for `/st shields` not working.