### PR TITLE
Dev to Live

### DIFF
--- a/Weapon Mods/Stable/TaitMod_Fletcher/Data/CubeBlocks/BoforSingleRemodel.sbc
+++ b/Weapon Mods/Stable/TaitMod_Fletcher/Data/CubeBlocks/BoforSingleRemodel.sbc
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-	<CubeBlocks>
+	<!--<CubeBlocks>
 		<Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
 			<Id>
 				<TypeId>ConveyorSorter</TypeId>
@@ -42,5 +42,5 @@
 				<Model BuildPercentUpperBound="1.00" File="Models\Cubes\large\BoforSingleRemodel_BS2.mwm"/>
 			</BuildProgressModels>
 		</Definition>
-	</CubeBlocks>
+	</CubeBlocks> -->
 </Definitions>

--- a/Weapon Mods/Stable/TaitMod_Fletcher/Data/Cubeblocks.sbc
+++ b/Weapon Mods/Stable/TaitMod_Fletcher/Data/Cubeblocks.sbc
@@ -948,7 +948,7 @@
       <MaxFov>1.04719755</MaxFov>
     </Definition> -->
 
-	  <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
+	  <!--<Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
 		  <Id>
 			  <TypeId>ConveyorSorter</TypeId>
         <SubtypeId>15cmTbtsKC36</SubtypeId>
@@ -1013,7 +1013,7 @@
       <ElevationSpeed>0.00025</ElevationSpeed>
       <MinFov>0.1</MinFov>
       <MaxFov>1.04719755</MaxFov>
-    </Definition>
+    </Definition> -->
 
 
 
@@ -1508,7 +1508,7 @@
 
 
 
-	  <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
+	 <!-- <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
 		  <Id>
 			  <TypeId>ConveyorSorter</TypeId>
         <SubtypeId>15cmSKC28R</SubtypeId>
@@ -1579,7 +1579,7 @@
       <ElevationSpeed>0.0005</ElevationSpeed>
       <MinFov>0.1</MinFov>
       <MaxFov>1.04719755</MaxFov>
-    </Definition>
+    </Definition> -->
 
 	  <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
 		  <Id>

--- a/Weapon Mods/Stable/TaitMod_Fletcher/Data/Scripts/CoreParts/127mm Shell.cs
+++ b/Weapon Mods/Stable/TaitMod_Fletcher/Data/Scripts/CoreParts/127mm Shell.cs
@@ -451,7 +451,7 @@ namespace Scripts
                 },
                 Grids = new GridSizeDef
                 {
-                    Large = -1f, // Multiplier for damage against large grids.
+                    Large = 1.1f, // Multiplier for damage against large grids.
                     Small = -1f, // Multiplier for damage against small grids.
                 },
                 Armor = new ArmorDef

--- a/Weapon Mods/Stable/TaitMod_Fletcher/Data/Scripts/CoreParts/25InSemiGuideTorp.cs
+++ b/Weapon Mods/Stable/TaitMod_Fletcher/Data/Scripts/CoreParts/25InSemiGuideTorp.cs
@@ -507,7 +507,7 @@ namespace Scripts
                 },
                 Grids = new GridSizeDef
                 {
-                    Large = 1.2f, // Multiplier for damage against large grids.
+                    Large = 1.25f, // Multiplier for damage against large grids.
                     Small = -1f, // Multiplier for damage against small grids.
                 },
                 Armor = new ArmorDef
@@ -586,7 +586,7 @@ namespace Scripts
                     NoSound = false,
                     ParticleScale = 1f,
                     CustomParticle = "", // Particle SubtypeID, from your Particle SBC
-                    CustomSound = "TORPLAND", // SubtypeID from your Audio SBC, not a filename
+                    CustomSound = "2CmFlak38FireDist", // SubtypeID from your Audio SBC, not a filename
                     Shape = Diamond, // Round or Diamond shape.  Diamond is more performance friendly.
                 },
             },


### PR DESCRIPTION
Scharnhorst/Elbing - removed for now
40mm single bofor - removed for now
Benson/Fletcher/Atlanta:
HE shell has had a 10% damage increase
Neptune Torpedo:
5% damage increase
Reload: 60 seconds - 45 seconds
Torpland sound now replaced with a basic one (no more taco belle bonk)