### PR TITLE
Update APES_WeaponTurret.cs

### DIFF
--- a/Weapon Mods/Stable/TIOStarcore/Data/Scripts/CoreParts/Laser Turrets/APES_WeaponTurret.cs
+++ b/Weapon Mods/Stable/TIOStarcore/Data/Scripts/CoreParts/Laser Turrets/APES_WeaponTurret.cs
@@ -51,10 +51,10 @@ namespace Scripts {
                 MaximumDiameter = 0, // Maximum radius of threat to engage; 0 = unlimited.
                 MaxTargetDistance = 0, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
                 MinTargetDistance = 0, // Minimum distance at which targets will be automatically shot at.
-                TopTargets = 24, // Maximum number of targets to randomize between; 0 = unlimited.
-                CycleTargets = 4, // Number of targets to "cycle" per acquire attempt.
-                TopBlocks = 8, // Maximum number of blocks to randomize between; 0 = unlimited.
-                CycleBlocks = 1, // Number of blocks to "cycle" per acquire attempt.
+                TopTargets = 0, // Maximum number of targets to randomize between; 0 = unlimited.
+                CycleTargets = 0, // Number of targets to "cycle" per acquire attempt.
+                TopBlocks = 0, // Maximum number of blocks to randomize between; 0 = unlimited.
+                CycleBlocks = 0, // Number of blocks to "cycle" per acquire attempt.
                 StopTrackingSpeed = 0, // Do not track threats traveling faster than this speed; 0 = unlimited.
                 UniqueTargetPerWeapon = false, // only applies to multi-weapon blocks 
                 MaxTrackingTime = 0, // After this time has been reached the weapon will stop tracking existing target and scan for a new one, only applies to turreted weapons


### PR DESCRIPTION
Removed cycle targets to test anti strikecraft preformance in scrims tonight