### PR TITLE
Update Environment.sbc

### DIFF
--- a/Utility Mods/Stable/SC_Season_4_Adjustments/Data/Environment.sbc
+++ b/Utility Mods/Stable/SC_Season_4_Adjustments/Data/Environment.sbc
@@ -6,7 +6,7 @@
       <TypeId>EnvironmentDefinition</TypeId>
       <SubtypeId>Default</SubtypeId>
     </Id>
-    <LargeShipMaxAngularSpeed>180</LargeShipMaxAngularSpeed>
+    <LargeShipMaxAngularSpeed>90</LargeShipMaxAngularSpeed>
 
 	<PlanetProperties>
         <AtmosphereIntensityMultiplier>17</AtmosphereIntensityMultiplier>


### PR DESCRIPTION
Draft, more for discussion and also I would forget to do this again if I didn't do it now.

Instead of rts limiting, why not just tweak global rotational speed then? Don't go all the way down to vanilla values, maybe 1.5-2x would be better than 3x tho?  Discuss.


Disclaimers, I remember this being the rotational speed limit, I think it's in degrees per second, and off the top of my head the vanilla value is 60.
Edited from my phone 🤔