### PR TITLE
Reworked Fusion Waste Heat

### DIFF
--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/CubeBlocks/Caster_FocusLens.sbc
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/CubeBlocks/Caster_FocusLens.sbc
@@ -19,9 +19,9 @@
 			<Model>Models\Caster_FocusLens.mwm</Model>
 			<Components>
 				<Component Subtype="SteelPlate" Count="100" />
+				<Component Subtype="LargeTube" Count="40" />
 				<Component Subtype="Construction" Count="150" />
 				<Component Subtype="MetalGrid" Count="250" />
-				<Component Subtype="LargeTube" Count="40" />
 				<Component Subtype="Construction" Count="30" />
 				<Component Subtype="SteelPlate" Count="50" />
 			</Components>

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/CubeBlocks/Caster_Reactor.sbc
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/CubeBlocks/Caster_Reactor.sbc
@@ -19,13 +19,13 @@
 			<Model>Models\Caster_Reactor.mwm</Model>
 			<Components>
 				<Component Subtype="SteelPlate" Count="800" />
+				<Component Subtype="Computer" Count="75" />
 				<Component Subtype="Construction" Count="70" />
 				<Component Subtype="MetalGrid" Count="40" />
 				<Component Subtype="LargeTube" Count="40" />
 				<Component Subtype="Superconductor" Count="100" />
 				<Component Subtype="Reactor" Count="2000" />
 				<Component Subtype="Motor" Count="20" />
-				<Component Subtype="Computer" Count="75" />
 				<Component Subtype="SteelPlate" Count="200" />
 			</Components>
 			<CriticalComponent Subtype="Computer" Index="0" />

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionPart.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionPart.cs
@@ -6,6 +6,8 @@ using Sandbox.Game.EntityComponents;
 using Sandbox.ModAPI;
 using Sandbox.ModAPI.Interfaces.Terminal;
 using StarCore.FusionSystems.Communication;
+using StarCore.FusionSystems.HeatParts;
+using VRage.Game;
 using VRage.Game.Components;
 using VRage.Game.ModAPI;
 using VRage.Game.ModAPI.Network;
@@ -213,6 +215,29 @@ namespace StarCore.FusionSystems.FusionParts
             ((IMyTerminalBlock)Block).AppendingCustomInfo += AppendingCustomInfo;
 
             NeedsUpdate |= MyEntityUpdateEnum.EACH_FRAME;
+        }
+
+        public override void UpdateAfterSimulation()
+        {
+            base.UpdateAfterSimulation();
+
+            try
+            {
+                if (!MyAPIGateway.Session.IsServer)
+                    return;
+
+                float heatLevel = HeatManager.I.GetGridHeatLevel(Block.CubeGrid);
+                if (heatLevel > 0.8f)
+                {
+                    // 10h^8
+                    float damagePerTick = 100 * heatLevel * heatLevel * heatLevel * heatLevel * heatLevel * heatLevel * heatLevel * heatLevel;
+                    Block.SlimBlock.DoDamage(damagePerTick, MyDamageType.Temperature, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                ModularApi.Log(ex.ToString());
+            }
         }
 
         #endregion

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionReactor/FusionReactorLogic.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionReactor/FusionReactorLogic.cs
@@ -32,7 +32,7 @@ namespace StarCore.FusionSystems.FusionParts.FusionReactor
             // Power generation consumed (per second)
             var powerConsumption = powerGeneration * 60 * reactorConsumptionMultiplier;
 
-            var reactorEfficiencyMultiplier = 1 / (0.669f + reactorConsumptionMultiplier);
+            var reactorEfficiencyMultiplier = 1 / (0.489f + reactorConsumptionMultiplier);
 
             // Power generated (per second)
             var reactorOutput = reactorEfficiencyMultiplier * powerConsumption * megawattsPerFusionPower;

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionThruster/FusionThrusterLogic.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/FusionThruster/FusionThrusterLogic.cs
@@ -32,7 +32,7 @@ namespace StarCore.FusionSystems.FusionParts.FusionThruster
             // Power generation consumed (per second)
             var powerConsumption = powerGeneration * 60 * consumptionMultiplier;
 
-            var efficiencyMultiplier = 1 / (0.669f + consumptionMultiplier);
+            var efficiencyMultiplier = 1 / (0.489f + consumptionMultiplier);
 
             // Power generated (per second)
             var thrustOutput = efficiencyMultiplier * powerConsumption * newtonsPerFusionPower;

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/S_FusionSystem.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/FusionParts/S_FusionSystem.cs
@@ -173,7 +173,8 @@ namespace StarCore.FusionSystems.
 
         private void UpdatePower(bool updateReactors = false)
         {
-            var generationModifier = 1 / (HeatManager.I.GetGridHeatLevel(Grid) + 0.5f);
+            //var generationModifier = 1 / (HeatManager.I.GetGridHeatLevel(Grid) + 0.5f);
+            var generationModifier = 1;
             var powerGeneration = float.Epsilon;
             var powerCapacity = float.Epsilon;
             var totalPowerUsage = 0f;
@@ -201,9 +202,6 @@ namespace StarCore.FusionSystems.
                     thruster?.UpdatePower(powerGeneration, NewtonsPerFusionPower * generationModifier, Thrusters.Count);
             }
 
-            ModularApi.SetAssemblyProperty(PhysicalAssemblyId, "HeatGeneration",
-                PowerGeneration * MegawattsPerFusionPower);
-
             // Subtract power usage afterwards so that all reactors have the same stats.
             PowerGeneration = powerGeneration;
             MaxPowerStored = powerCapacity;
@@ -213,7 +211,9 @@ namespace StarCore.FusionSystems.
             // Update PowerStored
             PowerStored += PowerGeneration;
             if (PowerStored > MaxPowerStored) PowerStored = MaxPowerStored;
-            //PowerGeneration = 0;
+
+            ModularApi.SetAssemblyProperty(PhysicalAssemblyId, "HeatGeneration",
+                PowerConsumption * MegawattsPerFusionPower);
         }
 
         public void UpdateTick()

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/HeatParts/GridHeatManager.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/HeatParts/GridHeatManager.cs
@@ -21,7 +21,7 @@ namespace StarCore.FusionSystems.HeatParts
 
         public float HeatGeneration;
 
-        public float HeatRatio = float.PositiveInfinity;
+        public float HeatRatio = float.Epsilon;
 
         public float HeatStored;
 

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/HudHelpers/ConsumptionBar.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/HudHelpers/ConsumptionBar.cs
@@ -52,9 +52,10 @@ namespace StarCore.FusionSystems.HudHelpers
                 Color = new Color(1, 1, 1, 1f)
             };
 
-            _noticeLabel = new LabelBox(parent)
+            _noticeLabel = new LabelBox(body)
             {
-                ParentAlignment = ParentAlignments.Bottom | ParentAlignments.Right,
+                ParentAlignment = ParentAlignments.Bottom | ParentAlignments.Left | ParentAlignments.InnerH,
+                CanIgnoreMasking = true,
                 Text = "Something went wrong...",
                 Color = new Color(0, 0, 0, 0),
                 BuilderMode = TextBuilderModes.Lined
@@ -95,6 +96,12 @@ namespace StarCore.FusionSystems.HudHelpers
             if (playerCockpit == null || _shouldHide)
             {
                 if (Visible) Visible = false;
+
+                if (_soundEmitter != null)
+                {
+                    _soundEmitter.StopSound(true);
+                    _soundEmitter = null;
+                }
                 return;
             }
 
@@ -145,12 +152,12 @@ namespace StarCore.FusionSystems.HudHelpers
             _noticeLabel.Text = new RichText
             {
                 {"Reactor Integrity: ", GlyphFormat.White},
-                {(reactorIntegrity*100).ToString("N0") + "%", GlyphFormat.White.WithColor(reactorIntegrity > 0.51 ? Color.White : Color.Red)}
+                {(reactorIntegrity*100).ToString("N0") + "%", GlyphFormat.White.WithColor(reactorIntegrity > 0.52 ? Color.White : Color.Red)}
             };
 
             if (HeatManager.I.GetGridHeatLevel(playerGrid) > 0.8f)
             {
-                _noticeLabel.TextBoard.Append("\nTAKING THERMAL DAMAGE!", GlyphFormat.White.WithColor(Color.Red));
+                _noticeLabel.TextBoard.Append("\nTAKING THERMAL DAMAGE", GlyphFormat.White.WithColor(Color.Red));
 
                 if (_soundEmitter == null)
                 {
@@ -160,17 +167,9 @@ namespace StarCore.FusionSystems.HudHelpers
                     };
                     _soundEmitter.PlaySound(_alertSound);
                 }
-
-                if (_ticks % 10 == 0)
-                {
-                    _heatBar.Visible = !_heatBar.Visible;
-                }
             }
             else
             {
-                if (!_heatBar.Visible)
-                    _heatBar.Visible = true;
-
                 if (_soundEmitter != null)
                 {
                     _soundEmitter.StopSound(true);

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/HudHelpers/ConsumptionBar.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/HudHelpers/ConsumptionBar.cs
@@ -1,11 +1,17 @@
 ﻿using System;
+using RichHudFramework;
+using RichHudFramework.Internal;
 using RichHudFramework.UI;
 using RichHudFramework.UI.Client;
 using RichHudFramework.UI.Rendering;
+using Sandbox.Game;
+using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using StarCore.FusionSystems.Communication;
 using StarCore.FusionSystems.FusionParts;
 using StarCore.FusionSystems.HeatParts;
+using VRage.Audio;
+using VRage.Game.Entity;
 using VRage.Input;
 using VRageMath;
 
@@ -16,7 +22,10 @@ namespace StarCore.FusionSystems.HudHelpers
         private readonly TexturedBox _storageBackground;
         private readonly TexturedBox _storageBar;
         private readonly TexturedBox _heatBar;
+        private readonly LabelBox _noticeLabel;
         private bool _shouldHide;
+        private MyEntity3DSoundEmitter _soundEmitter = null;
+        private readonly MySoundPair _alertSound = new MySoundPair("ArcSoundBlockAlert2");
 
 
         public ConsumptionBar(HudParentBase parent) : base(parent)
@@ -43,6 +52,14 @@ namespace StarCore.FusionSystems.HudHelpers
                 Color = new Color(1, 1, 1, 1f)
             };
 
+            _noticeLabel = new LabelBox(parent)
+            {
+                ParentAlignment = ParentAlignments.Bottom | ParentAlignments.Right,
+                Text = "Something went wrong...",
+                Color = new Color(0, 0, 0, 0),
+                BuilderMode = TextBuilderModes.Lined
+            };
+
             BodyColor = new Color(0, 0, 0, 0);
             BorderColor = new Color(0, 0, 0, 0);
 
@@ -64,8 +81,10 @@ namespace StarCore.FusionSystems.HudHelpers
             MinimumSize = new Vector2(Math.Max(1, MinimumSize.X), MinimumSize.Y);
         }
 
+        private int _ticks = 0;
         public void Update()
         {
+            _ticks++;
             var playerCockpit = MyAPIGateway.Session?.Player?.Controller?.ControlledEntity?.Entity as IMyShipController;
 
             // Pulling the current HudState is SLOOOOWWWW, so we only pull it when tab is just pressed.
@@ -84,6 +103,8 @@ namespace StarCore.FusionSystems.HudHelpers
             float totalFusionCapacity = 0;
             float totalFusionGeneration = 0;
             float totalFusionStored = 0;
+            float reactorIntegrity = 0;
+
             foreach (var system in SFusionManager.I.FusionSystems)
             {
                 if (playerGrid != ModularApi.GetAssemblyGrid(system.Key))
@@ -92,6 +113,12 @@ namespace StarCore.FusionSystems.HudHelpers
                 totalFusionCapacity += system.Value.MaxPowerStored;
                 totalFusionGeneration += system.Value.PowerGeneration;
                 totalFusionStored += system.Value.PowerStored;
+                foreach (var reactor in system.Value.Reactors)
+                {
+                    reactorIntegrity += reactor.Block.SlimBlock.Integrity/reactor.Block.SlimBlock.MaxIntegrity;
+                }
+
+                reactorIntegrity /= system.Value.Reactors.Count;
             }
 
             // Hide HUD element if the grid has no fusion systems (capacity is always >0 for a fusion system)
@@ -115,6 +142,42 @@ namespace StarCore.FusionSystems.HudHelpers
                 timeToCharge = 0;
 
             HeaderText = $"Fusion | {(totalFusionGeneration > 0 ? "+" : "-")}{Math.Round(timeToCharge)}s";
+            _noticeLabel.Text = new RichText
+            {
+                {"Reactor Integrity: ", GlyphFormat.White},
+                {(reactorIntegrity*100).ToString("N0") + "%", GlyphFormat.White.WithColor(reactorIntegrity > 0.51 ? Color.White : Color.Red)}
+            };
+
+            if (HeatManager.I.GetGridHeatLevel(playerGrid) > 0.8f)
+            {
+                _noticeLabel.TextBoard.Append("\nTAKING THERMAL DAMAGE!", GlyphFormat.White.WithColor(Color.Red));
+
+                if (_soundEmitter == null)
+                {
+                    _soundEmitter = new MyEntity3DSoundEmitter((MyEntity) playerCockpit.Entity)
+                    {
+                        CanPlayLoopSounds = true
+                    };
+                    _soundEmitter.PlaySound(_alertSound);
+                }
+
+                if (_ticks % 10 == 0)
+                {
+                    _heatBar.Visible = !_heatBar.Visible;
+                }
+            }
+            else
+            {
+                if (!_heatBar.Visible)
+                    _heatBar.Visible = true;
+
+                if (_soundEmitter != null)
+                {
+                    _soundEmitter.StopSound(true);
+                    _soundEmitter = null;
+                }
+            }
+
             _storageBar.Height = storagePct * _storageBackground.Height;
 
             float heatPct = HeatManager.I.GetGridHeatLevel(playerGrid);

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/S_FusionPlayerHud.cs
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/Data/Scripts/ModularAssemblies/S_FusionPlayerHud.cs
@@ -76,7 +76,7 @@ namespace StarCore.FusionSystems
                             continue;
 
                         MyVisualScriptLogicProvider.AddQuestlogDetailLocal(
-                            $"[{system.PhysicalAssemblyId}] Power: {Math.Round(system.PowerStored / system.MaxPowerStored * 100f)}% ({Math.Round(system.MaxPowerStored)} @ {Math.Round(system.PowerGeneration * 60, 1)}/s) | Loops: {system.Arms.Count} | Heat: -{HeatManager.I.GetGridHeatDissipation(system.Grid):N0} +{HeatManager.I.GetGridHeatGeneration(system.Grid):N0}",
+                            $"[{system.PhysicalAssemblyId}] Power: {Math.Round(system.PowerStored / system.MaxPowerStored * 100f)}% ({Math.Round(system.MaxPowerStored)} @ {Math.Round(system.PowerGeneration * 60, 1)}/s) | Loops: {system.Arms.Count} | Heat: -{HeatManager.I.GetGridHeatDissipation(system.Grid):N0} +{HeatManager.I.GetGridHeatGeneration(system.Grid):N0} ({HeatManager.I.GetGridHeatLevel(system.Grid)*100:F1}%)",
                             false, false);
                         displayedCount++;
                     }

--- a/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/MoA Fusion Systems.csproj.DotSettings
+++ b/Utility Mods/Stable/Modular Assembly Mods/MoA Fusion Systems/MoA Fusion Systems.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=data/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=data_005Cscripts/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=data_005Cscripts_005Cmodularassemblies/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
High (>80%) levels of waste heat now damage fusion reactors and thrusters on your grid.