### PR TITLE
Created Crossed Climbing Cost Groups

### DIFF
--- a/Gamemode Mods/Stable/Starcore_Pointslist/Data/Scripts/Additions/PointAdditions.cs
+++ b/Gamemode Mods/Stable/Starcore_Pointslist/Data/Scripts/Additions/PointAdditions.cs
@@ -943,12 +943,14 @@ namespace ShipPoints
                     break;
                 case "Shield Controller":
                 case "Shield Controller Table":
+                    blockDisplayName = "Shield Controller";
+                    costMultiplier = 50.00f;
+                    break;
                 case "Structural Integrity Field Generator":
-		case "Structural Integrity Generator Core":
+		        case "[S.I] Generator Core":
                     blockDisplayName = "Defensive Generator";
                     costMultiplier = 50.00f;
                     break;
-
                 case "[FAS] Neptune Torpedo":
                     blockDisplayName = "[FAS] Neptune Torpedo";
                     costMultiplier = 0.25f;
@@ -958,10 +960,22 @@ namespace ShipPoints
             return new MyTuple<string, float>(blockDisplayName, costMultiplier);
         }
 
+        /// <summary>
+        /// Groups listed here will not have climbing cost applied within their group, but will have it applied to other groups in the same category.
+        /// </summary>
+        private readonly string[][] _crossedClimbingCostGroups = {
+            new[]
+            {
+                "Shield Controller",
+                "Defensive Generator"
+            }
+        };
+
         public override void Init(MyObjectBuilder_SessionComponent sessionComponent)
         {
             MyAPIGateway.Utilities.SendModMessage(2546247, PointValues);
             MyAPIGateway.Utilities.SendModMessage(2546247, _climbingCostRename);
+            MyAPIGateway.Utilities.SendModMessage(2546247, _crossedClimbingCostGroups);
         }
     }
 }

--- a/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/AllGridsList.cs
+++ b/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/AllGridsList.cs
@@ -25,6 +25,7 @@ namespace StarCore.ShareTrack
         public static AllGridsList I;
 
         public static Dictionary<string, int> PointValues = new Dictionary<string, int>();
+        public static string[][] CrossedClimbingCostGroups = Array.Empty<string[]>();
 
 
         private static readonly Dictionary<long, IMyPlayer> AllPlayers = new Dictionary<long, IMyPlayer>();
@@ -102,6 +103,14 @@ namespace StarCore.ShareTrack
                 if (climbCostFunc != null)
                 {
                     _climbingCostFunction = climbCostFunc;
+                    return;
+                }
+
+                var crossedGroups = message as string[][];
+                if (crossedGroups != null)
+                {
+                    CrossedClimbingCostGroups = crossedGroups;
+                    return;
                 }
             }
             catch (Exception ex)

--- a/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracking/GridStats.cs
+++ b/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/ShipTracking/GridStats.cs
@@ -271,7 +271,13 @@ namespace StarCore.ShareTrack.ShipTracking
             if (!BlockCounts.ContainsKey(blockDisplayName))
                 BlockCounts.Add(blockDisplayName, 0);
 
-            var thisSpecialBlocksCount = BlockCounts[blockDisplayName]++;
+            int thisSpecialBlocksCount = BlockCounts[blockDisplayName]++;
+
+            string[] crossedGroup = AllGridsList.CrossedClimbingCostGroups.FirstOrDefault(l => l.Contains(blockDisplayName));
+            if (crossedGroup != null)
+            {
+                thisSpecialBlocksCount = crossedGroup.Where(g => g != blockDisplayName).Sum(groupName => BlockCounts.GetValueOrDefault(groupName, 0));
+            }
 
             if (thisClimbingCostMult > 0)
                 blockPoints += (int)(blockPoints * thisSpecialBlocksCount * thisClimbingCostMult);


### PR DESCRIPTION
Groups listed here will not have climbing cost applied within their group, but will have it applied to other groups in the same category. Effectively removes climbing cost for shield controllers and SI gens, UNLESS paired together.