### PR TITLE
Add SUGMA ClearLCD Feature

### DIFF
--- a/Gamemode Mods/Stable/StarCore SUGMA Gamemodes/Data/Scripts/SUGMA/Commands/CommandHandler.cs
+++ b/Gamemode Mods/Stable/StarCore SUGMA Gamemodes/Data/Scripts/SUGMA/Commands/CommandHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Sandbox.ModAPI;
+using SC.SUGMA.Utilities;
 
 namespace SC.SUGMA.Commands
 {
@@ -70,7 +71,12 @@ namespace SC.SUGMA.Commands
                 "SUGMA.Utils",
                 "Automatically balance tracked grids",
                 CommandMethods.AutoBalance
-            )
+            ),
+            ["clearlcd"] = new Command(
+                "SUGMA.Utils",
+                "Clear all image lcds.",
+                args => SUtils.ClearImageLcds()
+                )
 
             #endregion
         };

--- a/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/AllGridsList.cs
+++ b/Gamemode Mods/Stable/Starcore_Sharetrack/Data/Scripts/ShipPoints/AllGridsList.cs
@@ -377,6 +377,7 @@ namespace StarCore.ShareTrack
 
             WcApi?.Unload();
             ShieldApi?.Unload();
+            RtsApi?.Unload();
             if (PointValues != null)
             {
                 PointValues.Clear();


### PR DESCRIPTION
Clears all LCDs in the world with more than 1000 chars in their text field. This should save a small amount of performance.

Triggered by command or on match start (if scrim mode is disabled).