### PR TITLE
Blink Drive Power Draw

### DIFF
--- a/Utility Mods/SCMobilityBlocks/Data/CubeBlock_CustomBlink.sbc
+++ b/Utility Mods/SCMobilityBlocks/Data/CubeBlock_CustomBlink.sbc
@@ -8,7 +8,7 @@
       </Id>
       <DisplayName>Standard Blink Drive</DisplayName>
       <Icon>Textures\GUI\Icons\BlinkDriveIcon.dds</Icon>
-      <Description>1Km teleport. Holds 3 charges. Each charge takes 100MW and 60s to recharge.</Description>
+      <Description>1Km teleport. Holds 3 charges. Each charge takes 300MW and 60s to recharge.</Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
       <Size x="3" y="3" z="3" />

--- a/Utility Mods/SCMobilityBlocks/Data/Scripts/InvalidsCustomBlink/CustomBlinkDrive.cs
+++ b/Utility Mods/SCMobilityBlocks/Data/Scripts/InvalidsCustomBlink/CustomBlinkDrive.cs
@@ -39,7 +39,7 @@ namespace Invalid.BlinkDrive
         private const int RechargeTimeSeconds = 60;
         private const int MaxCharges = 3;
 
-        private float GetPowerDraw => JumpTimerSync > 0 ? 100 : 0.25f;
+        private float GetPowerDraw => JumpTimerSync > 0 ? 300 : 0.25f;
         private bool CanJump => Block.IsWorking && Block.IsFunctional && MaxCharges > 0;
 
         static bool controlsCreated = false;


### PR DESCRIPTION
why were SI tanks buffed, reducing blink charge to 100MW.  I think it used to be 500MW, but was told to set it to 300MW for now.