### PR TITLE
attempt to improve siege formula 

### DIFF
--- a/Utility Mods/SCDefenseBlocks/Data/Scripts/OneFuckingFolderDeeper/FieldGenerator/FieldGenerator_Config.cs
+++ b/Utility Mods/SCDefenseBlocks/Data/Scripts/OneFuckingFolderDeeper/FieldGenerator/FieldGenerator_Config.cs
@@ -33,8 +33,8 @@ namespace Starcore.FieldGenerator
         public float MaxPowerDraw = 500.00f;
         public float MinPowerDraw = 50.00f;
 
-        public int MaxSiegeTime = 60;
-        public int MinSiegeTime = 15;
+        public int MaxSiegeTime = 60; // this refers to max time spent you are able to be in siege mode.
+        public int MinSiegeTime = 10; // this refers to min time spent sieging in the cooldown formula, any time spent in siege below this number will count as this value for the cooldown formula. thus the minimum cooldown time is this number * 2.
         public int SiegePowerDraw = 900;
         public float SiegeModeResistence = 0.9f;      
   

--- a/Utility Mods/SCDefenseBlocks/Data/Scripts/OneFuckingFolderDeeper/FieldGenerator/FieldGenerator_Core.cs
+++ b/Utility Mods/SCDefenseBlocks/Data/Scripts/OneFuckingFolderDeeper/FieldGenerator/FieldGenerator_Core.cs
@@ -471,7 +471,7 @@ namespace Starcore.FieldGenerator
 
             SiegeBlockEnabler(Block.CubeGrid.GetFatBlocks<IMyFunctionalBlock>(), true);
 
-            SiegeCooldownTime.Value = (SiegeElapsedTime.Value > Config.MinSiegeTime) ? (SiegeElapsedTime.Value * 2) : Config.MinSiegeTime;
+            SiegeCooldownTime.Value = 2 * (SiegeElapsedTime.Value > Config.MinSiegeTime ? SiegeElapsedTime.Value : Config.MinSiegeTime);
             SiegeElapsedTime.Value = 0;
             SiegeCooldownActive.Value = true;
         }


### PR DESCRIPTION
found an issue of discontinuity in the siege math, this should fix it.  Set min siege time from 15 -> 20 for now.
The issue was any time spent in siege between 8 seconds and 15 seconds was worth an incorrect 15 seconds of cooldown, and the 16th second was worth a correct 32 seconds of cooldown.

Now there is a smooth transition, the first 10 seconds are worth 20 seconds of cooldown, and the 11th second is 22s of cooldown, the 12th second is 24s of cooldown, etc.

Tested and confirmed to work in single player.