### PR TITLE
Some minor buffs

### DIFF
--- a/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/15Cm55TwinCasemate.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/15Cm55TwinCasemate.sbc
@@ -9,7 +9,7 @@
 			<DisplayName>[FAS] Graf Zeppelin</DisplayName>
 			<Description>
 				[Turret Range: 5000]
-				[Reload: 3 Seconds/Barrel]
+				[Reload: 1.6 Seconds/Barrel]
 
 				[Ammo Types: HE | AP]
 				[Shell Range: 7km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/15cm45Casemate.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/15cm45Casemate.sbc
@@ -9,7 +9,7 @@
 			<DisplayName>[FAS] Baden</DisplayName>
 			<Description>
 				[Turret Range: 5000]
-				[Reload: 3 Seconds/Barrel]
+				[Reload: 1.6 Seconds/Barrel]
 
 				[Ammo Types: HE | AP]
 				[Shell Range: 7km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/203Triple.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/203Triple.sbc
@@ -9,7 +9,7 @@
 			<DisplayName>[FAS] Des Moines</DisplayName>
 			<Description>
 				[Turret Range: 5000]
-				[Reload: 3 Seconds/Barrel]
+				[Reload: 1.6 Seconds/Barrel]
 
 				[Ammo Types: HE | AP]
 				[Shell Range: 7km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/203Twin.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/203Twin.sbc
@@ -9,7 +9,7 @@
 			<DisplayName>[FAS] Hipper</DisplayName>
 			<Description>
 				[Turret Range: 5000]
-				[Reload: 3 Seconds/Barrel]
+				[Reload: 1.6 Seconds/Barrel]
 
 				[Ammo Types: HE | AP]
 				[Shell Range: 7km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/4_5Inch45.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/4_5Inch45.sbc
@@ -9,7 +9,7 @@
 			<DisplayName>[FAS] Dido</DisplayName>
 			<Description>
 				[Turret Range: 4000]
-				[Reload: 1.5 Seconds/Barrel]
+				[Reload: 1 Seconds/Barrel]
 
 				[Ammo Types: HE | SAP]
 				[Shell Range: 5km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/5InchQF.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/CubeBlocks/5InchQF.sbc
@@ -9,7 +9,7 @@
 			<DisplayName>[FAS] Montana </DisplayName>
 			<Description>
 				[Turret Range: 4000]
-				[Reload: 1.5 Seconds/Barrel]
+				[Reload: 1 Seconds/Barrel]
 
 				[Ammo Types: HE | SAP]
 				[Shell Range: 5km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/Cubeblocks.sbc
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Cubeblocks.sbc
@@ -726,7 +726,7 @@
       <DisplayName>[FAS] Atlanta</DisplayName>
 	<Description>
 		[Turret Range: 4000]
-        [Reload: 1.5 Seconds/Barrel]
+        [Reload: 1 Seconds/Barrel]
 
         [Ammo Types: HE | SAP]
         [Shell Range: 5km]
@@ -802,7 +802,7 @@
       <DisplayName>[FAS] Benson</DisplayName>
 	<Description>
 		[Turret Range: 4000]
-        [Reload: 1.5 Seconds/Barrel]
+        [Reload: 1 Seconds/Barrel]
 
         [Ammo Types: HE | SAP]
         [Shell Range: 5km]
@@ -877,7 +877,7 @@
       <DisplayName>[FAS] Fletcher</DisplayName>
 	<Description>
 		[Turret Range: 4000]
-        [Reload: 1.5 Seconds/Barrel]
+        [Reload: 1 Seconds/Barrel]
 
         [Ammo Types: HE | SAP]
         [Shell Range: 5km]
@@ -960,7 +960,7 @@
       <DisplayName>[FAS] Helena</DisplayName>
 		  <Description>
 			  [Turret Range: 4000]
-			  [Reload: 1.5 Seconds/Barrel]
+			  [Reload: 1 Seconds/Barrel]
 
 			  [Ammo Types: HE | SAP]
 			  [Shell Range: 5km]

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Large Calibre/508AP.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Large Calibre/508AP.cs
@@ -53,7 +53,7 @@ namespace Scripts
             },
             ObjectsHit = new ObjectsHitDef
             {
-                MaxObjectsHit = 6, // Limits the number of entities (grids, players, projectiles) the projectile can penetrate; 0 = unlimited.
+                MaxObjectsHit = 10, // Limits the number of entities (grids, players, projectiles) the projectile can penetrate; 0 = unlimited.
                 CountBlocks = true, // Counts individual blocks, not just entities hit.
             },
             Fragment = new FragmentDef // Formerly known as Shrapnel. Spawns specified ammo fragments on projectile death (via hit or detonation).

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark12.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark12.cs
@@ -131,7 +131,7 @@ namespace Scripts {
                     HeatSinkRate = 9000000, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 1, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 75, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 60, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = false, // Whether the weapon should fire the full magazine (or the full burst instead if ShotsInBurst > 0), even if the target is lost or the player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its magazine or burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark24.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark24.cs
@@ -131,7 +131,7 @@ namespace Scripts {
                     HeatSinkRate = 9000000, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 1, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 75, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 60, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = false, // Whether the weapon should fire the full magazine (or the full burst instead if ShotsInBurst > 0), even if the target is lost or the player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its magazine or burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark32.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark32.cs
@@ -132,7 +132,7 @@ namespace Scripts {
                     HeatSinkRate = 9000000, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 1, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 75, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 60, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = false, // Whether the weapon should fire the full magazine (or the full burst instead if ShotsInBurst > 0), even if the target is lost or the player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its magazine or burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark56.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/127mmMark56.cs
@@ -127,7 +127,7 @@ namespace Scripts {
                     HeatSinkRate = 9000000, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 1, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 75, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 60, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = false, // Whether the weapon should fire the full magazine (or the full burst instead if ShotsInBurst > 0), even if the target is lost or the player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its magazine or burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/152mmTripleUSI127mmCON.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/152mmTripleUSI127mmCON.cs
@@ -135,7 +135,7 @@ namespace Scripts {
                     HeatSinkRate = 9000000, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 1, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 75, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 60, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = false, // Whether the weapon should fire the full magazine (or the full burst instead if ShotsInBurst > 0), even if the target is lost or the player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its magazine or burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.

--- a/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/4_5 inch Mark  II.cs
+++ b/Weapon Mods/TaitMod_Fletcher/Data/Scripts/CoreParts/Small Calibre/4_5 inch Mark  II.cs
@@ -132,7 +132,7 @@ namespace Scripts {
                     HeatSinkRate = 9000000, // Amount of heat lost per second.
                     DegradeRof = false, // Progressively lower rate of fire when over 80% heat threshold (80% of max heat).
                     ShotsInBurst = 1, // Use this if you don't want the weapon to fire an entire physical magazine in one go. Should not be more than your magazine capacity.
-                    DelayAfterBurst = 75, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayAfterBurst = 60, // How long to spend "reloading" after each burst. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     FireFull = false, // Whether the weapon should fire the full magazine (or the full burst instead if ShotsInBurst > 0), even if the target is lost or the player stops firing prematurely.
                     GiveUpAfter = false, // Whether the weapon should drop its current target and reacquire a new target after finishing its magazine or burst.
                     BarrelSpinRate = 0, // Visual only, 0 disables and uses RateOfFire.


### PR DESCRIPTION
Descriptions updated: Reload time in seconds now accurate for 8 inch set
- 5 Inch gun chnages (Fletcher group)
	- Fire rate increased from 1.5 seconds to 1 second between fire events

- Sovreign
	- AP shell max pen from 6 blocks to 10